### PR TITLE
feat: Guards par zone (#13)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppService } from './app.service';
 import { QueueModule } from './queue';
 import { AuthModule, JwtAuthGuard, RolesGuard, PermissionsGuard } from './auth';
 import { TenantModule, TenantGuard } from './tenant';
+import { ZoneGuard } from './guards';
 
 @Module({
   imports: [QueueModule, AuthModule, TenantModule],
@@ -15,6 +16,11 @@ import { TenantModule, TenantGuard } from './tenant';
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,
+    },
+    // Enable zone-based access control globally
+    {
+      provide: APP_GUARD,
+      useClass: ZoneGuard,
     },
     // Enable role-based access control globally
     {
@@ -34,4 +40,5 @@ import { TenantModule, TenantGuard } from './tenant';
   ],
 })
 export class AppModule {}
+
 

--- a/apps/api/src/guards/index.ts
+++ b/apps/api/src/guards/index.ts
@@ -1,0 +1,3 @@
+export * from './zones';
+export * from './zone.decorator';
+export * from './zone.guard';

--- a/apps/api/src/guards/zone.decorator.ts
+++ b/apps/api/src/guards/zone.decorator.ts
@@ -1,0 +1,61 @@
+import { SetMetadata, applyDecorators, UseGuards } from '@nestjs/common';
+import { Zone, ZONE_ROLES } from './zones';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Public } from '../auth/decorators/public.decorator';
+import { SkipTenantCheck } from '../tenant/skip-tenant-check.decorator';
+
+export const ZONE_KEY = 'zone';
+
+/**
+ * Decorator to mark a controller or route as belonging to a specific zone.
+ * Automatically applies the appropriate role restrictions.
+ * 
+ * @example
+ * @Controller('portal/profile')
+ * @Zone(Zone.PORTAL)
+ * export class ProfileController { ... }
+ * 
+ * @example
+ * @Controller('admin/tenants')
+ * @Zone(Zone.ADMIN)
+ * export class AdminTenantsController { ... }
+ */
+export function ZoneAccess(zone: Zone) {
+  const decorators = [SetMetadata(ZONE_KEY, zone)];
+
+  if (zone === Zone.PUBLIC) {
+    decorators.push(Public());
+    decorators.push(SkipTenantCheck());
+  } else {
+    const roles = ZONE_ROLES[zone];
+    if (roles.length > 0) {
+      decorators.push(Roles(...roles));
+    }
+  }
+
+  return applyDecorators(...decorators);
+}
+
+/**
+ * Shorthand decorators for common zones
+ */
+
+/**
+ * Public zone - no auth required
+ */
+export const PublicZone = () => ZoneAccess(Zone.PUBLIC);
+
+/**
+ * Owner portal zone - for owners, tenants, council members
+ */
+export const PortalZone = () => ZoneAccess(Zone.PORTAL);
+
+/**
+ * Manager zone - for property managers and admins
+ */
+export const ManageZone = () => ZoneAccess(Zone.MANAGE);
+
+/**
+ * Platform admin zone - for super admins only
+ */
+export const AdminZone = () => ZoneAccess(Zone.ADMIN);

--- a/apps/api/src/guards/zone.guard.ts
+++ b/apps/api/src/guards/zone.guard.ts
@@ -1,0 +1,51 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ZONE_KEY } from './zone.decorator';
+import { Zone, ZONE_ROLES } from './zones';
+
+/**
+ * Guard that validates access based on zone configuration.
+ * This is an additional layer on top of RolesGuard for zone-specific logic.
+ */
+@Injectable()
+export class ZoneGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const zone = this.reflector.getAllAndOverride<Zone>(ZONE_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    // No zone specified, allow access (will be handled by other guards)
+    if (!zone) {
+      return true;
+    }
+
+    // Public zone always allowed
+    if (zone === Zone.PUBLIC) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+
+    if (!user) {
+      throw new ForbiddenException('Authentication required for this zone');
+    }
+
+    const allowedRoles = ZONE_ROLES[zone];
+    if (!allowedRoles.includes(user.role)) {
+      throw new ForbiddenException(
+        `Access denied. Zone '${zone}' requires one of: ${allowedRoles.join(', ')}`,
+      );
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/guards/zones.ts
+++ b/apps/api/src/guards/zones.ts
@@ -1,0 +1,42 @@
+/**
+ * Zone Guards for Le Copropriétaire
+ * 
+ * The application has different zones with different access requirements:
+ * 
+ * 1. PUBLIC ZONE (/api/auth/*, /api/health)
+ *    - No authentication required
+ *    - No tenant context
+ *    - Use: @Public() + @SkipTenantCheck()
+ * 
+ * 2. OWNER PORTAL (/api/portal/*)
+ *    - Authentication required
+ *    - Roles: owner, tenant, council
+ *    - Tenant context required (owner's tenant)
+ * 
+ * 3. MANAGER ZONE (/api/manage/*)
+ *    - Authentication required
+ *    - Roles: manager, admin
+ *    - Tenant context required
+ * 
+ * 4. PLATFORM ADMIN (/api/admin/*)
+ *    - Authentication required
+ *    - Role: platform_admin only
+ *    - Optional tenant context (for impersonation)
+ */
+
+export enum Zone {
+  PUBLIC = 'public',
+  PORTAL = 'portal',        // Espace copropriétaire
+  MANAGE = 'manage',        // Espace gestionnaire
+  ADMIN = 'admin',          // Admin plateforme
+}
+
+/**
+ * Roles allowed in each zone
+ */
+export const ZONE_ROLES: Record<Zone, string[]> = {
+  [Zone.PUBLIC]: [], // No authentication needed
+  [Zone.PORTAL]: ['owner', 'tenant', 'council', 'manager', 'admin', 'platform_admin'],
+  [Zone.MANAGE]: ['manager', 'admin', 'platform_admin'],
+  [Zone.ADMIN]: ['platform_admin'],
+};


### PR DESCRIPTION
## Description

Implementation des guards par zone pour controler l'acces aux differentes parties de l'application.

## Zones definies

| Zone | Chemin | Roles autorises |
|------|--------|-----------------|
| PUBLIC | /api/auth/*, /api/health | Aucun (pas d'auth) |
| PORTAL | /api/portal/* | owner, tenant, council, manager, admin, platform_admin |
| MANAGE | /api/manage/* | manager, admin, platform_admin |
| ADMIN | /api/admin/* | platform_admin uniquement |

## Decorateurs

### @ZoneAccess(zone)
Applique automatiquement les restrictions de role pour la zone.

### Raccourcis
- `@PublicZone()` - Routes publiques
- `@PortalZone()` - Espace coproprietaire
- `@ManageZone()` - Espace gestionnaire
- `@AdminZone()` - Admin plateforme

## Exemple

```typescript
@Controller('portal/profile')
@PortalZone()
export class ProfileController {
  @Get()
  getProfile(@CurrentUser() user) { ... }
}

@Controller('admin/tenants')
@AdminZone()
export class AdminTenantsController {
  @Get()
  listTenants() { ... }
}
```

## Integration

ZoneGuard est enregistre globalement dans AppModule (avant RolesGuard).

## Issue liee

Closes #13