### PR TITLE
feat(auth): Connect AuthService to real Drizzle DB

### DIFF
--- a/apps/api/src/auth/dto/auth.dto.ts
+++ b/apps/api/src/auth/dto/auth.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsString, MinLength, IsOptional } from 'class-validator';
 
 export class LoginDto {
   @IsEmail()
@@ -24,6 +24,10 @@ export class RegisterDto {
   @IsString()
   @MinLength(2)
   lastName: string;
+
+  @IsString()
+  @IsOptional()
+  companyName?: string;
 }
 
 export class AuthResponse {

--- a/apps/api/src/auth/guards/permissions.guard.ts
+++ b/apps/api/src/auth/guards/permissions.guard.ts
@@ -1,7 +1,7 @@
 import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { PERMISSIONS_KEY } from '../decorators/permissions.decorator';
-import { Permission, UserRole, hasAllPermissions } from '../rbac/permissions';
+import { Permission, Role, hasAllPermissions } from '../rbac/permissions';
 import { JwtPayload } from '../strategies/jwt.strategy';
 
 @Injectable()
@@ -26,7 +26,7 @@ export class PermissionsGuard implements CanActivate {
       throw new ForbiddenException('User not authenticated');
     }
 
-    const userRole = user.role as UserRole;
+    const userRole = user.role as Role;
     const hasAccess = hasAllPermissions(userRole, requiredPermissions);
 
     if (!hasAccess) {

--- a/apps/api/src/auth/rbac/permissions.ts
+++ b/apps/api/src/auth/rbac/permissions.ts
@@ -2,7 +2,7 @@
  * User roles in the system
  * Hierarchical from least to most privileged
  */
-export enum UserRole {
+export enum Role {
   // Locataire - resident of a lot
   TENANT = 'tenant',
   
@@ -91,8 +91,8 @@ export enum Permission {
 /**
  * Role to permissions mapping
  */
-export const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
-  [UserRole.TENANT]: [
+export const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
+  [Role.TENANT]: [
     // Basic view access
     Permission.CONDO_VIEW,
     Permission.LOT_VIEW,
@@ -104,7 +104,7 @@ export const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
     Permission.FINANCE_VIEW, // Own finances only
   ],
 
-  [UserRole.OWNER]: [
+  [Role.OWNER]: [
     // Everything tenant can do plus:
     Permission.CONDO_VIEW,
     Permission.LOT_VIEW,
@@ -121,7 +121,7 @@ export const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
     Permission.REPORT_VIEW,
   ],
 
-  [UserRole.COUNCIL]: [
+  [Role.COUNCIL]: [
     // Everything owner can do plus:
     Permission.CONDO_VIEW,
     Permission.LOT_VIEW,
@@ -142,7 +142,7 @@ export const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
     Permission.ANNOUNCEMENT_CREATE,
   ],
 
-  [UserRole.MANAGER]: [
+  [Role.MANAGER]: [
     // Full management access
     Permission.USER_VIEW,
     Permission.USER_CREATE,
@@ -176,7 +176,7 @@ export const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
     Permission.SETTINGS_VIEW,
   ],
 
-  [UserRole.ADMIN]: [
+  [Role.ADMIN]: [
     // Everything manager can do plus user deletion and settings
     Permission.USER_VIEW,
     Permission.USER_CREATE,
@@ -214,7 +214,7 @@ export const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
     Permission.SETTINGS_UPDATE,
   ],
 
-  [UserRole.PLATFORM_ADMIN]: [
+  [Role.PLATFORM_ADMIN]: [
     // All permissions including tenant management
     ...Object.values(Permission),
   ],
@@ -223,7 +223,7 @@ export const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
 /**
  * Check if a role has a specific permission
  */
-export function hasPermission(role: UserRole, permission: Permission): boolean {
+export function hasPermission(role: Role, permission: Permission): boolean {
   const permissions = ROLE_PERMISSIONS[role];
   return permissions?.includes(permission) ?? false;
 }
@@ -231,20 +231,20 @@ export function hasPermission(role: UserRole, permission: Permission): boolean {
 /**
  * Check if a role has all of the specified permissions
  */
-export function hasAllPermissions(role: UserRole, permissions: Permission[]): boolean {
+export function hasAllPermissions(role: Role, permissions: Permission[]): boolean {
   return permissions.every((p) => hasPermission(role, p));
 }
 
 /**
  * Check if a role has any of the specified permissions
  */
-export function hasAnyPermission(role: UserRole, permissions: Permission[]): boolean {
+export function hasAnyPermission(role: Role, permissions: Permission[]): boolean {
   return permissions.some((p) => hasPermission(role, p));
 }
 
 /**
  * Get all permissions for a role
  */
-export function getPermissionsForRole(role: UserRole): Permission[] {
+export function getPermissionsForRole(role: Role): Permission[] {
   return ROLE_PERMISSIONS[role] ?? [];
 }

--- a/apps/api/src/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.ts
@@ -2,10 +2,12 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 
+export type UserRole = 'platform_admin' | 'admin' | 'manager' | 'council' | 'owner' | 'tenant';
+
 export interface JwtPayload {
   sub: string; // user id
   email: string;
-  role: 'platform_admin' | 'manager' | 'owner' | 'tenant';
+  role: UserRole;
   tenantId: string | null; // null for platform_admin
 }
 

--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const API_URL = process.env.API_URL || "http://localhost:3001";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002";
 
 export async function POST(request: NextRequest) {
   try {

--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const API_URL = process.env.API_URL || "http://localhost:3001";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002";
 
 export async function POST(request: NextRequest) {
   try {


### PR DESCRIPTION
## Description
- Replace mock auth with real Drizzle ORM queries
- Create tenant automatically on manager registration  
- Add companyName field to RegisterDto
- Fix BFF routes to use correct API port 3002
- Rename UserRole enum to Role to avoid conflicts
- Add active status check on login

## Testing
✅ Register creates user + tenant in DB
✅ Login returns valid JWT with correct payload

## Related Issues
Closes #9, Closes #10, Closes #11