### PR TITLE
feat(multi-tenant): Enforce tenant isolation on all data routes

### DIFF
--- a/apps/api/src/bank/bank.controller.ts
+++ b/apps/api/src/bank/bank.controller.ts
@@ -1,37 +1,39 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query, ForbiddenException } from '@nestjs/common';
 import { BankService } from './bank.service';
 import { CurrentTenantId } from '../tenant/current-tenant.decorator';
-import { Public } from '../auth/decorators/public.decorator';
 
 @Controller('bank')
 export class BankController {
   constructor(private readonly bankService: BankService) {}
 
   @Get('accounts')
-  @Public() // TODO: Remove after auth is properly configured
   async findAllAccounts(
     @CurrentTenantId() tenantId: string,
     @Query('condominiumId') condominiumId?: string,
   ) {
-    const tid = tenantId || 'default';
-    return this.bankService.findAllAccounts(tid, condominiumId);
+    if (!tenantId) {
+      throw new ForbiddenException('Tenant context is required');
+    }
+    return this.bankService.findAllAccounts(tenantId, condominiumId);
   }
 
   @Get('accounts/:id')
-  @Public() // TODO: Remove after auth is properly configured
   async findOneAccount(@Param('id') id: string, @CurrentTenantId() tenantId: string) {
-    const tid = tenantId || 'default';
-    return this.bankService.findOneAccount(id, tid);
+    if (!tenantId) {
+      throw new ForbiddenException('Tenant context is required');
+    }
+    return this.bankService.findOneAccount(id, tenantId);
   }
 
   @Get('transactions')
-  @Public() // TODO: Remove after auth is properly configured
   async findAllTransactions(
     @CurrentTenantId() tenantId: string,
     @Query('accountId') accountId?: string,
     @Query('condominiumId') condominiumId?: string,
   ) {
-    const tid = tenantId || 'default';
-    return this.bankService.findAllTransactions(tid, accountId, condominiumId);
+    if (!tenantId) {
+      throw new ForbiddenException('Tenant context is required');
+    }
+    return this.bankService.findAllTransactions(tenantId, accountId, condominiumId);
   }
 }

--- a/apps/api/src/condominiums/condominiums.controller.ts
+++ b/apps/api/src/condominiums/condominiums.controller.ts
@@ -1,23 +1,24 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, ForbiddenException } from '@nestjs/common';
 import { CondominiumsService } from './condominiums.service';
 import { CurrentTenantId } from '../tenant/current-tenant.decorator';
-import { Public } from '../auth/decorators/public.decorator';
 
 @Controller('condominiums')
 export class CondominiumsController {
   constructor(private readonly condominiumsService: CondominiumsService) {}
 
   @Get()
-  @Public() // TODO: Remove after auth is properly configured
   async findAll(@CurrentTenantId() tenantId: string) {
-    const tid = tenantId || 'default';
-    return this.condominiumsService.findAll(tid);
+    if (!tenantId) {
+      throw new ForbiddenException('Tenant context is required');
+    }
+    return this.condominiumsService.findAll(tenantId);
   }
 
   @Get(':id')
-  @Public() // TODO: Remove after auth is properly configured
   async findOne(@Param('id') id: string, @CurrentTenantId() tenantId: string) {
-    const tid = tenantId || 'default';
-    return this.condominiumsService.findOne(id, tid);
+    if (!tenantId) {
+      throw new ForbiddenException('Tenant context is required');
+    }
+    return this.condominiumsService.findOne(id, tenantId);
   }
 }

--- a/apps/api/src/dashboard/dashboard.controller.ts
+++ b/apps/api/src/dashboard/dashboard.controller.ts
@@ -1,23 +1,24 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, ForbiddenException } from '@nestjs/common';
 import { DashboardService } from './dashboard.service';
 import { CurrentTenantId } from '../tenant/current-tenant.decorator';
-import { Public } from '../auth/decorators/public.decorator';
 
 @Controller('dashboard')
 export class DashboardController {
   constructor(private readonly dashboardService: DashboardService) {}
 
   @Get('stats')
-  @Public() // TODO: Remove after auth is properly configured
   async getStats(@CurrentTenantId() tenantId: string) {
-    const tid = tenantId || 'default';
-    return this.dashboardService.getStats(tid);
+    if (!tenantId) {
+      throw new ForbiddenException('Tenant context is required');
+    }
+    return this.dashboardService.getStats(tenantId);
   }
 
   @Get('condominiums-with-unpaid')
-  @Public() // TODO: Remove after auth is properly configured
   async getCondominiumsWithUnpaid(@CurrentTenantId() tenantId: string) {
-    const tid = tenantId || 'default';
-    return this.dashboardService.getCondominiumsWithUnpaid(tid);
+    if (!tenantId) {
+      throw new ForbiddenException('Tenant context is required');
+    }
+    return this.dashboardService.getCondominiumsWithUnpaid(tenantId);
   }
 }

--- a/apps/api/src/documents/documents.controller.ts
+++ b/apps/api/src/documents/documents.controller.ts
@@ -1,26 +1,27 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query, ForbiddenException } from '@nestjs/common';
 import { DocumentsService } from './documents.service';
 import { CurrentTenantId } from '../tenant/current-tenant.decorator';
-import { Public } from '../auth/decorators/public.decorator';
 
 @Controller('documents')
 export class DocumentsController {
   constructor(private readonly documentsService: DocumentsService) {}
 
   @Get()
-  @Public() // TODO: Remove after auth is properly configured
   async findAll(
     @CurrentTenantId() tenantId: string,
     @Query('condominiumId') condominiumId?: string,
   ) {
-    const tid = tenantId || 'default';
-    return this.documentsService.findAll(tid, condominiumId);
+    if (!tenantId) {
+      throw new ForbiddenException('Tenant context is required');
+    }
+    return this.documentsService.findAll(tenantId, condominiumId);
   }
 
   @Get(':id')
-  @Public() // TODO: Remove after auth is properly configured
   async findOne(@Param('id') id: string, @CurrentTenantId() tenantId: string) {
-    const tid = tenantId || 'default';
-    return this.documentsService.findOne(id, tid);
+    if (!tenantId) {
+      throw new ForbiddenException('Tenant context is required');
+    }
+    return this.documentsService.findOne(id, tenantId);
   }
 }

--- a/apps/api/src/owners/owners.controller.ts
+++ b/apps/api/src/owners/owners.controller.ts
@@ -1,24 +1,24 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, ForbiddenException } from '@nestjs/common';
 import { OwnersService } from './owners.service';
 import { CurrentTenantId } from '../tenant/current-tenant.decorator';
-import { Public } from '../auth/decorators/public.decorator';
 
 @Controller('owners')
 export class OwnersController {
   constructor(private readonly ownersService: OwnersService) {}
 
   @Get()
-  @Public() // TODO: Remove after auth is properly configured
   async findAll(@CurrentTenantId() tenantId: string) {
-    // For now, use a default tenant ID if not provided
-    const tid = tenantId || 'default';
-    return this.ownersService.findAll(tid);
+    if (!tenantId) {
+      throw new ForbiddenException('Tenant context is required');
+    }
+    return this.ownersService.findAll(tenantId);
   }
 
   @Get(':id')
-  @Public() // TODO: Remove after auth is properly configured
   async findOne(@Param('id') id: string, @CurrentTenantId() tenantId: string) {
-    const tid = tenantId || 'default';
-    return this.ownersService.findOne(id, tid);
+    if (!tenantId) {
+      throw new ForbiddenException('Tenant context is required');
+    }
+    return this.ownersService.findOne(id, tenantId);
   }
 }


### PR DESCRIPTION
## Summary
Enforces proper multi-tenant data isolation by removing `@Public()` decorators and requiring tenant context on all data endpoints.

## Changes
- **Controllers updated**: condominiums, owners, documents, bank, dashboard
- **Removed**: `@Public()` decorator from all data routes
- **Added**: `ForbiddenException` when `tenantId` is missing
- **Behavior**: All data routes now require authenticated users with valid tenant context

## How it works
1. `TenantMiddleware` extracts `tenantId` from JWT token
2. `TenantGuard` ensures tenant context exists (except for platform_admin)
3. Each controller validates `tenantId` and passes it to services
4. Services filter all queries by `tenantId` for data isolation

## Testing
- ✅ API compiles without errors
- ✅ Routes require authentication (401 without token)
- ✅ Data queries filtered by tenant

Closes #12