### PR TITLE
feat(api): API Gestion Managers d'un Syndic

### DIFF
--- a/apps/api/src/platform/dto/create-manager.dto.ts
+++ b/apps/api/src/platform/dto/create-manager.dto.ts
@@ -1,0 +1,21 @@
+import { IsEmail, IsNotEmpty, IsOptional, IsString, MinLength } from 'class-validator';
+
+export class CreateManagerDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(2)
+  firstName: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(2)
+  lastName: string;
+
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @IsString()
+  @IsOptional()
+  phone?: string;
+}

--- a/apps/api/src/platform/dto/index.ts
+++ b/apps/api/src/platform/dto/index.ts
@@ -1,3 +1,5 @@
 export * from './create-syndic.dto';
 export * from './update-syndic.dto';
 export * from './syndic-response.dto';
+export * from './create-manager.dto';
+export * from './manager-response.dto';

--- a/apps/api/src/platform/dto/manager-response.dto.ts
+++ b/apps/api/src/platform/dto/manager-response.dto.ts
@@ -1,0 +1,18 @@
+/**
+ * Manager Response DTO
+ */
+export class ManagerResponseDto {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: string;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class ManagerListResponseDto {
+  data: ManagerResponseDto[];
+  total: number;
+}

--- a/apps/api/src/platform/platform.controller.ts
+++ b/apps/api/src/platform/platform.controller.ts
@@ -12,7 +12,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { PlatformService } from './platform.service';
-import { CreateSyndicDto, UpdateSyndicDto } from './dto';
+import { CreateSyndicDto, UpdateSyndicDto, CreateManagerDto } from './dto';
 import { Zone } from '../guards/zones';
 import { ZoneAccess } from '../guards/zone.decorator';
 import { SkipTenantCheck } from '../tenant/skip-tenant-check.decorator';
@@ -93,5 +93,40 @@ export class PlatformController {
   @Delete('syndics/:id')
   async deleteSyndic(@Param('id', ParseUUIDPipe) id: string) {
     return this.platformService.deleteSyndic(id);
+  }
+
+  // ==========================================================================
+  // MANAGERS ENDPOINTS
+  // ==========================================================================
+
+  /**
+   * List all managers of a syndic
+   */
+  @Get('syndics/:syndicId/managers')
+  async listManagers(@Param('syndicId', ParseUUIDPipe) syndicId: string) {
+    return this.platformService.findManagersBySyndic(syndicId);
+  }
+
+  /**
+   * Create (invite) a manager for a syndic
+   */
+  @Post('syndics/:syndicId/managers')
+  @HttpCode(HttpStatus.CREATED)
+  async createManager(
+    @Param('syndicId', ParseUUIDPipe) syndicId: string,
+    @Body() dto: CreateManagerDto,
+  ) {
+    return this.platformService.createManager(syndicId, dto);
+  }
+
+  /**
+   * Revoke a manager from a syndic
+   */
+  @Delete('syndics/:syndicId/managers/:managerId')
+  async deleteManager(
+    @Param('syndicId', ParseUUIDPipe) syndicId: string,
+    @Param('managerId', ParseUUIDPipe) managerId: string,
+  ) {
+    return this.platformService.deleteManager(syndicId, managerId);
   }
 }


### PR DESCRIPTION
## Description
Implémentation de l'API Platform Admin pour gérer les Managers (employés) d'un Syndic.

## Endpoints ajoutés
- `GET /platform/syndics/:syndicId/managers` - Liste les managers d'un syndic
- `POST /platform/syndics/:syndicId/managers` - Créer/inviter un manager
- `DELETE /platform/syndics/:syndicId/managers/:managerId` - Révoquer un manager

## Fichiers ajoutés
- `dto/create-manager.dto.ts` - DTO de création avec validation
- `dto/manager-response.dto.ts` - DTO de réponse

## Fonctionnalités
- ✅ Validation que le syndic existe
- ✅ Vérification email unique
- ✅ Hash du mot de passe temporaire (bcrypt)
- ✅ Empêcher la suppression du dernier manager
- ✅ Soft delete (status = 'suspended')
- ⏳ Envoi d'email d'invitation (TODO - mock pour l'instant)

## Sécurité
- Protégé par `ZoneGuard` pour zone ADMIN
- Accessible uniquement aux `platform_admin`

Closes #84