### PR TITLE
feat(api): add search endpoint for orphan owners

### DIFF
--- a/apps/api/src/owners/owners.controller.ts
+++ b/apps/api/src/owners/owners.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ForbiddenException } from '@nestjs/common';
+import { Controller, Get, Param, Query, ForbiddenException } from '@nestjs/common';
 import { OwnersService } from './owners.service';
 import { CurrentTenantId } from '../tenant/current-tenant.decorator';
 
@@ -12,6 +12,12 @@ export class OwnersController {
       throw new ForbiddenException('Tenant context is required');
     }
     return this.ownersService.findAll(tenantId);
+  }
+
+  @Get('search')
+  async searchOrphanOwners(@Query('q') query: string) {
+    // Search for orphan owners (no tenant) - accessible by any authenticated manager
+    return this.ownersService.searchOrphanOwners(query);
   }
 
   @Get(':id')

--- a/apps/api/src/owners/owners.service.ts
+++ b/apps/api/src/owners/owners.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { db } from '../database';
 import { users, lots, condominiums, sepaMandates, payments } from '../database/schema';
-import { eq, and, sql } from 'drizzle-orm';
+import { eq, and, sql, isNull, or, ilike } from 'drizzle-orm';
 
 @Injectable()
 export class OwnersService {
@@ -83,5 +83,49 @@ export class OwnersService {
       .limit(1);
 
     return owner[0] || null;
+  }
+
+  /**
+   * Search for orphan owners (owners without a tenantId)
+   * Matches by: firstName + lastName OR phone OR email
+   */
+  async searchOrphanOwners(query: string) {
+    if (!query || query.trim().length < 2) {
+      return [];
+    }
+
+    const searchTerm = query.trim();
+    const searchPattern = `%${searchTerm}%`;
+
+    // Search orphan owners (no tenantId) by name, phone, or email
+    const orphanOwners = await db
+      .select({
+        id: users.id,
+        firstName: users.firstName,
+        lastName: users.lastName,
+        email: users.email,
+        status: users.status,
+        createdAt: users.createdAt,
+      })
+      .from(users)
+      .where(
+        and(
+          eq(users.role, 'owner'),
+          isNull(users.tenantId),
+          or(
+            // Match firstName + lastName combination
+            sql`CONCAT(${users.firstName}, ' ', ${users.lastName}) ILIKE ${searchPattern}`,
+            // Match email
+            ilike(users.email, searchPattern),
+            // Match firstName alone
+            ilike(users.firstName, searchPattern),
+            // Match lastName alone
+            ilike(users.lastName, searchPattern)
+          )
+        )
+      )
+      .limit(20);
+
+    return orphanOwners;
   }
 }


### PR DESCRIPTION
## Description
Add an endpoint to search for owners who are not associated with any syndic (orphan owners).

## Endpoint
`GET /owners/search?q=...`

## Search Logic
Matches orphan owners by:
- Full name (firstName + lastName)
- Email address
- First name alone
- Last name alone

## Constraints
- Only returns owners with `tenantId IS NULL`
- Maximum 20 results
- Minimum 2 characters in search query

## Use Case
Managers can search for existing orphan owners to associate them with their syndic, instead of creating duplicates.

Fixes #95