### PR TITLE
feat(bff): add BFF routes for owners search and association

### DIFF
--- a/apps/web/src/app/api/owners/[id]/associate/route.ts
+++ b/apps/web/src/app/api/owners/[id]/associate/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+async function getAuthHeaders() {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+  
+  if (!accessToken) {
+    return null;
+  }
+  
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${accessToken}`,
+  };
+}
+
+// POST /api/owners/[id]/associate - Associate orphan owner to syndic
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const headers = await getAuthHeaders();
+  
+  if (!headers) {
+    return NextResponse.json({ message: "Non authentifié" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const response = await fetch(`${API_URL}/owners/${id}/associate`, {
+      method: "POST",
+      headers,
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { message: data.message || "Erreur lors de l'association" },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Owner associate error:", error);
+    return NextResponse.json(
+      { message: "Erreur de connexion au serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/owners/search/route.ts
+++ b/apps/web/src/app/api/owners/search/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002";
+
+async function getAuthHeaders() {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+  
+  if (!accessToken) {
+    return null;
+  }
+  
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${accessToken}`,
+  };
+}
+
+// GET /api/owners/search?q=... - Search orphan owners
+export async function GET(request: NextRequest) {
+  const headers = await getAuthHeaders();
+  
+  if (!headers) {
+    return NextResponse.json({ message: "Non authentifié" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get("q") || "";
+
+  // Validate minimum search length
+  if (query.length < 2) {
+    return NextResponse.json([]);
+  }
+
+  try {
+    const response = await fetch(
+      `${API_URL}/owners/search?q=${encodeURIComponent(query)}`,
+      { headers }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { message: data.message || "Erreur serveur" },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Owners search error:", error);
+    return NextResponse.json(
+      { message: "Erreur de connexion au serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -36,6 +36,26 @@ export async function getOwners(): Promise<Owner[]> {
   return fetchApi<Owner[]>('/owners');
 }
 
+export interface OrphanOwner {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  status: string;
+  createdAt: string;
+}
+
+export async function searchOrphanOwners(query: string): Promise<OrphanOwner[]> {
+  if (!query || query.length < 2) return [];
+  return fetchApi<OrphanOwner[]>(`/owners/search?q=${encodeURIComponent(query)}`);
+}
+
+export async function associateOwnerToSyndic(ownerId: string): Promise<Owner> {
+  return fetchApi<Owner>(`/owners/${ownerId}/associate`, {
+    method: 'POST',
+  });
+}
+
 // Documents API
 export interface Document {
   id: string;


### PR DESCRIPTION
## Description
Add Next.js API routes (BFF) for owners search and association functionality.

## New Routes
- `GET /api/owners/search?q=...` - Search orphan owners (proxies to backend)
- `POST /api/owners/:id/associate` - Associate owner to syndic

## lib/api.ts Updates
- `searchOrphanOwners(query)` - Search function with 2-char minimum
- `associateOwnerToSyndic(ownerId)` - Associate function

## Notes
All routes pass the httpOnly cookie auth token to the backend.

Fixes #97