### PR TITLE
feat(bank): afficher état vide si pas de banque rattachée

### DIFF
--- a/apps/web/src/app/api/condominiums/[id]/bank/route.ts
+++ b/apps/web/src/app/api/condominiums/[id]/bank/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: condominiumId } = await params;
+  const cookieStore = await cookies();
+  const token = cookieStore.get("accessToken")?.value;
+
+  if (!token) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const response = await fetch(
+      `${API_URL}/bank/accounts?condominiumId=${condominiumId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      return NextResponse.json(error, { status: response.status });
+    }
+
+    const accounts = await response.json();
+    return NextResponse.json(accounts);
+  } catch (error) {
+    console.error("Error fetching bank accounts:", error);
+    return NextResponse.json(
+      { message: "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Description
Quand on arrive sur la page /app/condominiums/[id]/bank et qu'il n'y a pas de compte bancaire rattaché, on affiche maintenant un état vide avec un message explicite.

## Changements
- Ajout route BFF `/api/condominiums/[id]/bank` pour récupérer les comptes
- Fetch des comptes bancaires depuis l'API backend
- Affichage d'un état vide avec icône et message
- Bouton 'Connecter une banque' avec modal placeholder

## Screenshots
État vide avec bouton de connexion

Closes #108