### PR TITLE
feat(bank): afficher N/A pour les soldes si pas de banque rattachée

### DIFF
--- a/apps/web/src/app/app/bank/page.tsx
+++ b/apps/web/src/app/app/bank/page.tsx
@@ -103,6 +103,7 @@ export default function BankPage() {
   });
 
   const totalBalance = bankAccounts.reduce((sum, acc) => sum + acc.balance, 0);
+  const hasBankAccounts = bankAccounts.length > 0;
   const unmatchedCount = transactions.filter((tx) => tx.reconciliationStatus === "unmatched").length;
   const pendingCount = transactions.filter((tx) => tx.reconciliationStatus === "pending").length;
 
@@ -160,17 +161,21 @@ export default function BankPage() {
                 </div>
                 <div>
                   <p className="text-[13px] font-medium text-muted-foreground">Solde total</p>
-                  <p className="text-2xl font-semibold text-foreground">
-                    {totalBalance.toLocaleString("fr-FR", { minimumFractionDigits: 2 })} €
+                  <p className={`text-2xl font-semibold ${hasBankAccounts ? "text-foreground" : "text-muted-foreground"}`}>
+                    {hasBankAccounts 
+                      ? `${totalBalance.toLocaleString("fr-FR", { minimumFractionDigits: 2 })} €`
+                      : "N/A"}
                   </p>
                 </div>
               </div>
-              <div className="mt-4 flex items-center gap-4 text-[13px]">
-                <span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
-                  <TrendingUp className="h-4 w-4" />
-                  +2.5% ce mois
-                </span>
-              </div>
+              {hasBankAccounts && (
+                <div className="mt-4 flex items-center gap-4 text-[13px]">
+                  <span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+                    <TrendingUp className="h-4 w-4" />
+                    +2.5% ce mois
+                  </span>
+                </div>
+              )}
             </CardContent>
           </Card>
 

--- a/apps/web/src/app/app/condominiums/[id]/page.tsx
+++ b/apps/web/src/app/app/condominiums/[id]/page.tsx
@@ -131,9 +131,15 @@ export default function CondominiumDashboardPage({ params }: { params: Promise<{
         {[
           {
             label: "Solde actuel",
-            value: `${condominium.balance.toLocaleString("fr-FR")} €`,
+            value: condominium.hasBankAccount 
+              ? `${condominium.balance.toLocaleString("fr-FR")} €`
+              : "N/A",
             icon: DollarSign,
-            valueClass: condominium.balance < 0 ? "text-destructive" : "text-emerald-600 dark:text-emerald-400",
+            valueClass: !condominium.hasBankAccount 
+              ? "text-muted-foreground"
+              : condominium.balance < 0 
+                ? "text-destructive" 
+                : "text-emerald-600 dark:text-emerald-400",
           },
           {
             label: "Lots",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -171,6 +171,7 @@ export interface Condominium {
   lots: number;
   owners: number;
   balance: number;
+  hasBankAccount: boolean;
 }
 
 export async function getCondominiums(): Promise<Condominium[]> {
@@ -195,9 +196,9 @@ export interface CondominiumWithUnpaid {
   id: string;
   name: string;
   address: string;
-  latePayments: number;
   unpaidAmount: number;
   ownersInArrears: number;
+  failedDirectDebits: number;
 }
 
 export async function getDashboardStats(): Promise<DashboardStats> {


### PR DESCRIPTION
## Description

Si aucune banque n'est rattachée à une copropriété, les soldes ne peuvent pas être calculés. Cette PR affiche 'N/A' au lieu de 0 pour éviter de tromper l'utilisateur.

## Modifications

### Backend (condominiums.service.ts)
- Ajout du champ `hasBankAccount` qui vérifie l'existence d'une connexion Powens active
- Retourné dans `findAll` et `findOne`

### Frontend (api.ts)
- Mise à jour de l'interface `Condominium` avec le nouveau champ `hasBankAccount`

### Pages modifiées
- **Page détail copropriété** (`/app/condominiums/[id]`): Le solde actuel affiche 'N/A' si pas de banque, avec style grisé
- **Page banque** (`/app/bank`): Le solde total affiche 'N/A' si aucun compte bancaire connecté, masque la tendance

## Critères d'acceptation

- [x] Page détail copropriété: solde = N/A si pas de banque
- [x] Dashboard: gestion cohérente (pas de changement nécessaire - affiche des impayés)
- [x] Page bank: solde total = N/A si pas de compte

Closes #110