### PR TITLE
feat(bank): routes BFF pour afficher les banques synchronisées dans /app/bank

### DIFF
--- a/apps/web/src/app/api/bank/accounts/route.ts
+++ b/apps/web/src/app/api/bank/accounts/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+const API_URL = process.env.API_URL || 'http://localhost:3002';
+
+export async function GET(request: NextRequest) {
+  try {
+    const cookieStore = await cookies();
+    const accessToken = cookieStore.get('accessToken')?.value;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { message: 'Non authentifié' },
+        { status: 401 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const condominiumId = searchParams.get('condominiumId');
+    
+    const queryParams = condominiumId ? `?condominiumId=${condominiumId}` : '';
+    
+    const response = await fetch(`${API_URL}/bank/accounts${queryParams}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      return NextResponse.json(
+        { message: errorData.message || 'Erreur lors de la récupération des comptes' },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching bank accounts:', error);
+    return NextResponse.json(
+      { message: 'Erreur serveur' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/bank/transactions/route.ts
+++ b/apps/web/src/app/api/bank/transactions/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+const API_URL = process.env.API_URL || 'http://localhost:3002';
+
+export async function GET(request: NextRequest) {
+  try {
+    const cookieStore = await cookies();
+    const accessToken = cookieStore.get('accessToken')?.value;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { message: 'Non authentifié' },
+        { status: 401 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const accountId = searchParams.get('accountId');
+    const condominiumId = searchParams.get('condominiumId');
+    
+    const queryParams = new URLSearchParams();
+    if (accountId) queryParams.append('accountId', accountId);
+    if (condominiumId) queryParams.append('condominiumId', condominiumId);
+    const queryString = queryParams.toString() ? `?${queryParams.toString()}` : '';
+    
+    const response = await fetch(`${API_URL}/bank/transactions${queryString}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      return NextResponse.json(
+        { message: errorData.message || 'Erreur lors de la récupération des transactions' },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching transactions:', error);
+    return NextResponse.json(
+      { message: 'Erreur serveur' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Description

Cette PR ajoute les routes BFF nécessaires pour que la page `/app/bank` puisse afficher les comptes bancaires synchronisés via Powens.

## Modifications

### Nouvelles routes BFF

1. **`/api/bank/accounts`** (GET)
   - Récupère tous les comptes bancaires du tenant
   - Paramètre optionnel `condominiumId` pour filtrer par copropriété
   - Retourne: id, bankName, accountName, iban, balance, lastSyncAt, status, condominiumId, condominiumName

2. **`/api/bank/transactions`** (GET)
   - Récupère les transactions bancaires
   - Paramètres optionnels: `accountId`, `condominiumId`
   - Retourne: id, bankAccountId, amount, type, description, counterpartyName, transactionDate, reconciliationStatus, category

## Fonctionnement

Le flux complet est maintenant opérationnel:
1. L'utilisateur connecte une banque via Powens (modal dans `/app/condominiums/[id]/bank`)
2. Le callback Powens stocke la connexion et les comptes dans la BDD
3. La page `/app/bank` récupère et affiche tous les comptes via ces routes BFF
4. Le filtrage par copropriété est possible

## Critères d'acceptation

- [x] Les comptes Powens apparaissent dans /app/bank
- [x] Le nom de la copropriété est affiché
- [x] Les transactions sont listées

Closes #111