### PR TITLE
feat(owners): add pagination, search and condominium filter

### DIFF
--- a/apps/api/src/owners/owners.controller.ts
+++ b/apps/api/src/owners/owners.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Post, Delete, Param, Query, Body, ForbiddenException, ParseUUIDPipe } from '@nestjs/common';
-import { OwnersService } from './owners.service';
+import { OwnersService, FindAllOwnersParams } from './owners.service';
 import { CurrentTenantId } from '../tenant/current-tenant.decorator';
 import { ZoneAccess } from '../guards/zone.decorator';
 import { Zone } from '../guards/zones';
@@ -10,11 +10,23 @@ export class OwnersController {
   constructor(private readonly ownersService: OwnersService) {}
 
   @Get()
-  async findAll(@CurrentTenantId() tenantId: string) {
+  async findAll(
+    @CurrentTenantId() tenantId: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+    @Query('search') search?: string,
+    @Query('condominiumId') condominiumId?: string,
+  ) {
     if (!tenantId) {
       throw new ForbiddenException('Tenant context is required');
     }
-    return this.ownersService.findAll(tenantId);
+    const params: FindAllOwnersParams = {
+      page: page ? parseInt(page, 10) : 1,
+      limit: limit ? parseInt(limit, 10) : 10,
+      search: search || undefined,
+      condominiumId: condominiumId || undefined,
+    };
+    return this.ownersService.findAll(tenantId, params);
   }
 
   @Get('search')

--- a/apps/api/src/platform/platform.service.ts
+++ b/apps/api/src/platform/platform.service.ts
@@ -580,12 +580,33 @@ export class PlatformService {
       })
     );
 
+    // Get stats for the cards (global counts, not affected by filters)
+    const [pendingCount] = await db
+      .select({ count: count() })
+      .from(users)
+      .where(eq(users.status, 'pending'));
+
+    const [managersCount] = await db
+      .select({ count: count() })
+      .from(users)
+      .where(eq(users.role, 'manager'));
+
+    const [ownersCount] = await db
+      .select({ count: count() })
+      .from(users)
+      .where(eq(users.role, 'owner'));
+
     return {
       data: usersWithCondos,
       total,
       page,
       limit,
       totalPages: Math.ceil(total / limit),
+      stats: {
+        pending: pendingCount?.count || 0,
+        managers: managersCount?.count || 0,
+        owners: ownersCount?.count || 0,
+      },
     };
   }
 

--- a/apps/web/src/app/platform/users/page.tsx
+++ b/apps/web/src/app/platform/users/page.tsx
@@ -29,6 +29,12 @@ import {
 import { Search, MoreVertical, Link2, UserCheck, Users, Clock, Building2, Home } from "lucide-react";
 import { getPendingUsers, getSyndics, associateUserToSyndic, PendingUser, Syndic } from "@/lib/api";
 
+interface UserStats {
+  pending: number;
+  managers: number;
+  owners: number;
+}
+
 export default function PlatformUsersPage() {
   const [users, setUsers] = useState<PendingUser[]>([]);
   const [syndics, setSyndics] = useState<Syndic[]>([]);
@@ -38,6 +44,7 @@ export default function PlatformUsersPage() {
   const [roleFilter, setRoleFilter] = useState<string>("all");
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [total, setTotal] = useState(0);
+  const [stats, setStats] = useState<UserStats>({ pending: 0, managers: 0, owners: 0 });
   const [page, setPage] = useState(1);
   const limit = 10;
 
@@ -60,6 +67,9 @@ export default function PlatformUsersPage() {
       });
       setUsers(response.data);
       setTotal(response.total);
+      if (response.stats) {
+        setStats(response.stats);
+      }
     } catch (err) {
       console.error("Error fetching pending users:", err);
       setError(err instanceof Error ? err.message : "Erreur lors du chargement des utilisateurs");
@@ -170,7 +180,7 @@ export default function PlatformUsersPage() {
                 <p className="text-[13px] font-medium text-muted-foreground">En attente</p>
                 <div className="flex items-baseline gap-3">
                   <span className="text-4xl font-semibold tracking-tight text-foreground">
-                    {total}
+                    {stats.pending}
                   </span>
                 </div>
               </div>
@@ -189,7 +199,7 @@ export default function PlatformUsersPage() {
                 <p className="text-[13px] font-medium text-muted-foreground">Gestionnaires</p>
                 <div className="flex items-baseline gap-3">
                   <span className="text-4xl font-semibold tracking-tight text-foreground">
-                    {users.filter(u => u.role === "manager").length}
+                    {stats.managers}
                   </span>
                 </div>
               </div>
@@ -208,7 +218,7 @@ export default function PlatformUsersPage() {
                 <p className="text-[13px] font-medium text-muted-foreground">Copropriétaires</p>
                 <div className="flex items-baseline gap-3">
                   <span className="text-4xl font-semibold tracking-tight text-foreground">
-                    {users.filter(u => u.role === "owner").length}
+                    {stats.owners}
                   </span>
                 </div>
               </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -46,8 +46,30 @@ export interface Owner {
   hasSepaMandateActive: boolean;
 }
 
-export async function getOwners(): Promise<Owner[]> {
-  return fetchApi<Owner[]>('/owners');
+export interface OwnersResponse {
+  data: Owner[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface GetOwnersParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+  condominiumId?: string;
+}
+
+export async function getOwners(params: GetOwnersParams = {}): Promise<OwnersResponse> {
+  const searchParams = new URLSearchParams();
+  if (params.page) searchParams.set('page', params.page.toString());
+  if (params.limit) searchParams.set('limit', params.limit.toString());
+  if (params.search) searchParams.set('search', params.search);
+  if (params.condominiumId) searchParams.set('condominiumId', params.condominiumId);
+  
+  const queryString = searchParams.toString();
+  return fetchApi<OwnersResponse>(`/owners${queryString ? `?${queryString}` : ''}`);
 }
 
 export async function updateOwnerCondominiums(ownerId: string, condominiumIds: string[]): Promise<{ success: boolean; count: number }> {
@@ -357,11 +379,18 @@ export interface PlatformUser {
   condominiums: PlatformUserCondominium[];
 }
 
+export interface PlatformUserStats {
+  pending: number;
+  managers: number;
+  owners: number;
+}
+
 export interface PlatformUsersResponse {
   data: PlatformUser[];
   total: number;
   page: number;
   limit: number;
+  stats?: PlatformUserStats;
 }
 
 // Keep old type for backwards compatibility

--- a/scripts/seed-test-data.sql
+++ b/scripts/seed-test-data.sql
@@ -1,0 +1,355 @@
+-- ============================================================================
+-- SCRIPT DE GÉNÉRATION DE DONNÉES DE TEST
+-- ============================================================================
+-- Remplace 'TENANT_ID_HERE' par l'ID de ton syndic
+-- Exécute ce script dans Supabase SQL Editor
+-- ============================================================================
+
+-- Variable pour le tenant (syndic)
+-- Récupère le premier tenant ou remplace par l'ID souhaité
+DO $$
+DECLARE
+  v_tenant_id UUID := 'f2270fc1-1c1a-477d-adbd-baa971bd9733'; -- Syndic Test Copilot
+  v_condo_id UUID;
+  v_owner_id UUID;
+  v_lot_id UUID;
+  v_meter_id UUID;
+  v_bill_id UUID;
+  v_condo_name TEXT;
+  v_owner_first TEXT;
+  v_owner_last TEXT;
+  v_lot_ref TEXT;
+  v_lot_type TEXT;
+  v_meter_type TEXT;
+  v_condo_count INT := 5;
+  v_owners_per_condo INT;
+  v_lots_per_owner INT;
+  i INT;
+  j INT;
+  k INT;
+  m INT;
+  v_index_start DECIMAL;
+  v_index_end DECIMAL;
+  v_consumption DECIMAL;
+BEGIN
+  RAISE NOTICE 'Utilisation du tenant: %', v_tenant_id;
+
+  -- ============================================================================
+  -- CRÉATION DES COPROPRIÉTÉS
+  -- ============================================================================
+  
+  FOR i IN 1..v_condo_count LOOP
+    v_condo_name := CASE i
+      WHEN 1 THEN 'Résidence Les Jardins du Parc'
+      WHEN 2 THEN 'Le Clos des Lilas'
+      WHEN 3 THEN 'Domaine de la Fontaine'
+      WHEN 4 THEN 'Les Terrasses du Soleil'
+      WHEN 5 THEN 'Villa Montmartre'
+    END;
+
+    INSERT INTO condominiums (
+      id, tenant_id, name, address, postal_code, city, 
+      created_at, updated_at
+    ) VALUES (
+      gen_random_uuid(),
+      v_tenant_id,
+      v_condo_name,
+      (10 + i * 5)::TEXT || ' Rue de la République',
+      '75' || LPAD((i * 3)::TEXT, 3, '0'),
+      CASE i % 3 
+        WHEN 0 THEN 'Paris'
+        WHEN 1 THEN 'Lyon'
+        ELSE 'Marseille'
+      END,
+      NOW(),
+      NOW()
+    )
+    RETURNING id INTO v_condo_id;
+
+    RAISE NOTICE 'Créé copropriété: % (id: %)', v_condo_name, v_condo_id;
+
+    -- Nombre aléatoire de propriétaires (10 à 20)
+    v_owners_per_condo := 10 + (random() * 10)::INT;
+
+    -- ============================================================================
+    -- CRÉATION DES PROPRIÉTAIRES POUR CETTE COPRO
+    -- ============================================================================
+    
+    FOR j IN 1..v_owners_per_condo LOOP
+      v_owner_first := (ARRAY['Jean', 'Pierre', 'Marie', 'Sophie', 'Laurent', 'Isabelle', 'François', 'Catherine', 'Michel', 'Anne', 'Philippe', 'Nathalie', 'Alain', 'Christine', 'Bernard', 'Valérie', 'Patrick', 'Martine', 'Nicolas', 'Sandrine'])[1 + (random() * 19)::INT];
+      v_owner_last := (ARRAY['Martin', 'Bernard', 'Dubois', 'Thomas', 'Robert', 'Richard', 'Petit', 'Durand', 'Leroy', 'Moreau', 'Simon', 'Laurent', 'Lefebvre', 'Michel', 'Garcia', 'David', 'Bertrand', 'Roux', 'Vincent', 'Fournier'])[1 + (random() * 19)::INT];
+
+      -- Créer le user owner
+      INSERT INTO users (
+        id, tenant_id, email, password_hash, first_name, last_name,
+        role, status, created_at, updated_at
+      ) VALUES (
+        gen_random_uuid(),
+        v_tenant_id,
+        LOWER(v_owner_first || '.' || v_owner_last || '.' || i || '.' || j || '@test.lecopro.fr'),
+        '$2b$10$dummyhashnotusedfortesting12345678901234567890',
+        v_owner_first,
+        v_owner_last,
+        'owner',
+        'active',
+        NOW(),
+        NOW()
+      )
+      RETURNING id INTO v_owner_id;
+
+      -- Associer à la copropriété
+      INSERT INTO owner_condominiums (
+        id, tenant_id, owner_id, condominium_id, created_at
+      ) VALUES (
+        gen_random_uuid(),
+        v_tenant_id,
+        v_owner_id,
+        v_condo_id,
+        NOW()
+      );
+
+      -- Nombre de lots pour ce propriétaire (1 à 3)
+      v_lots_per_owner := 1 + (random() * 2)::INT;
+
+      -- ============================================================================
+      -- CRÉATION DES LOTS POUR CE PROPRIÉTAIRE
+      -- ============================================================================
+      
+      FOR k IN 1..v_lots_per_owner LOOP
+        v_lot_type := (ARRAY['apartment', 'parking', 'cellar', 'garage', 'commercial'])[1 + (random() * 4)::INT];
+        v_lot_ref := UPPER(CHR(64 + i)) || LPAD((j * 10 + k)::TEXT, 3, '0');
+
+        INSERT INTO lots (
+          id, tenant_id, condominium_id, owner_id, reference, type,
+          floor, surface, tantiemes, created_at, updated_at
+        ) VALUES (
+          gen_random_uuid(),
+          v_tenant_id,
+          v_condo_id,
+          v_owner_id,
+          v_lot_ref,
+          v_lot_type,
+          CASE v_lot_type 
+            WHEN 'parking' THEN -1
+            WHEN 'cellar' THEN -2
+            ELSE (random() * 6)::INT
+          END,
+          CASE v_lot_type
+            WHEN 'apartment' THEN 40 + (random() * 80)::DECIMAL
+            WHEN 'parking' THEN 12
+            WHEN 'cellar' THEN 8
+            WHEN 'garage' THEN 15
+            WHEN 'commercial' THEN 50 + (random() * 100)::DECIMAL
+          END,
+          CASE v_lot_type
+            WHEN 'apartment' THEN 100 + (random() * 400)::INT
+            WHEN 'parking' THEN 10 + (random() * 20)::INT
+            WHEN 'cellar' THEN 5 + (random() * 10)::INT
+            WHEN 'garage' THEN 15 + (random() * 20)::INT
+            WHEN 'commercial' THEN 200 + (random() * 300)::INT
+          END,
+          NOW(),
+          NOW()
+        )
+        RETURNING id INTO v_lot_id;
+
+        -- ============================================================================
+        -- CRÉATION DES COMPTEURS POUR CE LOT (seulement pour apartments)
+        -- ============================================================================
+        
+        IF v_lot_type = 'apartment' THEN
+          -- Compteurs à créer pour les appartements
+          FOREACH v_meter_type IN ARRAY ARRAY['cold_water', 'hot_water', 'heating'] LOOP
+            v_index_start := 1000 + (random() * 5000)::DECIMAL;
+            
+            INSERT INTO lot_meters (
+              id, tenant_id, lot_id, meter_type, meter_number,
+              is_dual_tariff, is_active, last_reading_date, last_reading_value,
+              created_at, updated_at
+            ) VALUES (
+              gen_random_uuid(),
+              v_tenant_id,
+              v_lot_id,
+              v_meter_type,
+              'CPT-' || UPPER(SUBSTRING(v_meter_type, 1, 2)) || '-' || LPAD((random() * 99999)::INT::TEXT, 5, '0'),
+              FALSE,
+              TRUE,
+              CURRENT_DATE - INTERVAL '30 days',
+              v_index_start,
+              NOW(),
+              NOW()
+            );
+          END LOOP;
+        END IF;
+      END LOOP;
+    END LOOP;
+
+    -- ============================================================================
+    -- CRÉATION DES FACTURES DE CHARGES POUR CETTE COPRO
+    -- ============================================================================
+    
+    -- Facture Eau Froide - Dernier trimestre
+    INSERT INTO utility_bills (
+      id, tenant_id, condominium_id, utility_type,
+      period_start, period_end, 
+      global_index_start, global_index_end,
+      total_consumption, unit, total_amount,
+      invoice_number, invoice_date, supplier_name, status,
+      created_at, updated_at
+    ) VALUES (
+      gen_random_uuid(),
+      v_tenant_id,
+      v_condo_id,
+      'cold_water',
+      CURRENT_DATE - INTERVAL '3 months',
+      CURRENT_DATE,
+      10000 + (random() * 1000)::INT,
+      10500 + (random() * 1000)::INT,
+      400 + (random() * 200)::DECIMAL,
+      'm3',
+      800 + (random() * 400)::DECIMAL,
+      'EF-2024-' || LPAD(i::TEXT, 3, '0'),
+      CURRENT_DATE - INTERVAL '5 days',
+      'Veolia Eau',
+      'draft',
+      NOW(),
+      NOW()
+    )
+    RETURNING id INTO v_bill_id;
+
+    -- Créer les relevés pour chaque compteur d'eau froide
+    INSERT INTO meter_readings (
+      id, tenant_id, utility_bill_id, lot_meter_id,
+      previous_index, current_index, consumption, allocated_amount,
+      created_at, updated_at
+    )
+    SELECT 
+      gen_random_uuid(),
+      v_tenant_id,
+      v_bill_id,
+      lm.id,
+      COALESCE(lm.last_reading_value, 1000),
+      COALESCE(lm.last_reading_value, 1000) + (10 + (random() * 50)::DECIMAL),
+      10 + (random() * 50)::DECIMAL,
+      (10 + (random() * 50)::DECIMAL) * 2.5,
+      NOW(),
+      NOW()
+    FROM lot_meters lm
+    INNER JOIN lots l ON lm.lot_id = l.id
+    WHERE l.condominium_id = v_condo_id
+    AND lm.meter_type = 'cold_water';
+
+    -- Facture Eau Chaude
+    INSERT INTO utility_bills (
+      id, tenant_id, condominium_id, utility_type,
+      period_start, period_end,
+      global_index_start, global_index_end,
+      total_consumption, unit, total_amount,
+      invoice_number, invoice_date, supplier_name, status,
+      created_at, updated_at
+    ) VALUES (
+      gen_random_uuid(),
+      v_tenant_id,
+      v_condo_id,
+      'hot_water',
+      CURRENT_DATE - INTERVAL '3 months',
+      CURRENT_DATE,
+      5000 + (random() * 500)::INT,
+      5200 + (random() * 500)::INT,
+      150 + (random() * 100)::DECIMAL,
+      'm3',
+      600 + (random() * 300)::DECIMAL,
+      'EC-2024-' || LPAD(i::TEXT, 3, '0'),
+      CURRENT_DATE - INTERVAL '5 days',
+      'Engie',
+      'draft',
+      NOW(),
+      NOW()
+    )
+    RETURNING id INTO v_bill_id;
+
+    INSERT INTO meter_readings (
+      id, tenant_id, utility_bill_id, lot_meter_id,
+      previous_index, current_index, consumption, allocated_amount,
+      created_at, updated_at
+    )
+    SELECT 
+      gen_random_uuid(),
+      v_tenant_id,
+      v_bill_id,
+      lm.id,
+      COALESCE(lm.last_reading_value, 500),
+      COALESCE(lm.last_reading_value, 500) + (5 + (random() * 25)::DECIMAL),
+      5 + (random() * 25)::DECIMAL,
+      (5 + (random() * 25)::DECIMAL) * 4.5,
+      NOW(),
+      NOW()
+    FROM lot_meters lm
+    INNER JOIN lots l ON lm.lot_id = l.id
+    WHERE l.condominium_id = v_condo_id
+    AND lm.meter_type = 'hot_water';
+
+    -- Facture Chauffage
+    INSERT INTO utility_bills (
+      id, tenant_id, condominium_id, utility_type,
+      period_start, period_end,
+      total_consumption, unit, total_amount,
+      invoice_number, invoice_date, supplier_name, status,
+      created_at, updated_at
+    ) VALUES (
+      gen_random_uuid(),
+      v_tenant_id,
+      v_condo_id,
+      'heating',
+      CURRENT_DATE - INTERVAL '4 months',
+      CURRENT_DATE - INTERVAL '1 month',
+      8000 + (random() * 4000)::DECIMAL,
+      'kwh',
+      2500 + (random() * 1500)::DECIMAL,
+      'CH-2024-' || LPAD(i::TEXT, 3, '0'),
+      CURRENT_DATE - INTERVAL '10 days',
+      'EDF',
+      'validated',
+      NOW(),
+      NOW()
+    )
+    RETURNING id INTO v_bill_id;
+
+    INSERT INTO meter_readings (
+      id, tenant_id, utility_bill_id, lot_meter_id,
+      previous_index, current_index, consumption, allocated_amount,
+      created_at, updated_at
+    )
+    SELECT 
+      gen_random_uuid(),
+      v_tenant_id,
+      v_bill_id,
+      lm.id,
+      COALESCE(lm.last_reading_value, 2000),
+      COALESCE(lm.last_reading_value, 2000) + (100 + (random() * 400)::DECIMAL),
+      100 + (random() * 400)::DECIMAL,
+      (100 + (random() * 400)::DECIMAL) * 0.18,
+      NOW(),
+      NOW()
+    FROM lot_meters lm
+    INNER JOIN lots l ON lm.lot_id = l.id
+    WHERE l.condominium_id = v_condo_id
+    AND lm.meter_type = 'heating';
+
+    RAISE NOTICE 'Copro % terminée avec % propriétaires', v_condo_name, v_owners_per_condo;
+  END LOOP;
+
+  -- ============================================================================
+  -- RÉSUMÉ
+  -- ============================================================================
+  RAISE NOTICE '============================================';
+  RAISE NOTICE 'GÉNÉRATION TERMINÉE';
+  RAISE NOTICE '============================================';
+  RAISE NOTICE 'Copropriétés créées: %', (SELECT COUNT(*) FROM condominiums WHERE tenant_id = v_tenant_id);
+  RAISE NOTICE 'Propriétaires créés: %', (SELECT COUNT(*) FROM users WHERE tenant_id = v_tenant_id AND role = 'owner');
+  RAISE NOTICE 'Lots créés: %', (SELECT COUNT(*) FROM lots WHERE tenant_id = v_tenant_id);
+  RAISE NOTICE 'Compteurs créés: %', (SELECT COUNT(*) FROM lot_meters WHERE tenant_id = v_tenant_id);
+  RAISE NOTICE 'Factures créées: %', (SELECT COUNT(*) FROM utility_bills WHERE tenant_id = v_tenant_id);
+  RAISE NOTICE 'Relevés créés: %', (SELECT COUNT(*) FROM meter_readings WHERE tenant_id = v_tenant_id);
+  
+END $$;


### PR DESCRIPTION
## Changes

### Backend (API)
- Add pagination (page, limit) to owners API
- Add server-side search filter
- Add condominium filter (condominiumId)
- Fix platform users stats to show correct global counts

### Frontend (Web)
- Add condominium dropdown filter next to search
- Add server-side search with 300ms debounce
- Add pagination controls (10/25/50/100/200 per page)
- Add page navigation at bottom
- Fix owner profile links to use correct route with condominiumId

### Other
- Add seed data script for test data generation