### PR TITLE
fix(owners): fix Select empty value + add SigNoz dashboards

### DIFF
--- a/apps/web/src/app/app/owners/page.tsx
+++ b/apps/web/src/app/app/owners/page.tsx
@@ -622,7 +622,7 @@ export default function OwnersPage() {
   const [totalPages, setTotalPages] = useState(0);
   
   // Filter state
-  const [selectedCondominiumId, setSelectedCondominiumId] = useState<string>("");
+  const [selectedCondominiumId, setSelectedCondominiumId] = useState<string>("all");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   
   // Modal state
@@ -660,7 +660,7 @@ export default function OwnersPage() {
         page,
         limit,
         search: debouncedSearch || undefined,
-        condominiumId: selectedCondominiumId || undefined,
+        condominiumId: selectedCondominiumId === "all" ? undefined : selectedCondominiumId,
       };
       const [ownersResponse, condosData] = await Promise.all([
         getOwners(params),
@@ -1035,7 +1035,7 @@ export default function OwnersPage() {
               <SelectValue placeholder="Toutes les copropriétés" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">Toutes les copropriétés</SelectItem>
+              <SelectItem value="all">Toutes les copropriétés</SelectItem>
               {condominiums.map((condo) => (
                 <SelectItem key={condo.id} value={condo.id}>
                   {condo.name}

--- a/signoz/dashboards/README.md
+++ b/signoz/dashboards/README.md
@@ -1,0 +1,114 @@
+# Dashboards SigNoz pour LeCopro API
+
+Ce dossier contient les définitions JSON des dashboards SigNoz pour monitorer l'API LeCopro.
+
+## Dashboards disponibles
+
+| Fichier | Description |
+|---------|-------------|
+| [api-overview.json](api-overview.json) | Vue d'ensemble de l'API (requêtes/min, latences, erreurs, top endpoints) |
+| [api-modules.json](api-modules.json) | Métriques par module (Auth, Owners, Condos, Payments, Bank, Documents) |
+| [api-errors.json](api-errors.json) | Suivi détaillé des erreurs HTTP 4xx/5xx et exceptions |
+| [api-database.json](api-database.json) | Monitoring des opérations base de données (Drizzle/PostgreSQL) |
+| [api-auth.json](api-auth.json) | Authentification : logins, tokens, sessions, erreurs 401 |
+| [api-business.json](api-business.json) | Métriques métier : créations d'entités, paiements, synchros bancaires |
+
+## Configuration requise
+
+Ces dashboards utilisent les traces OpenTelemetry envoyées par l'API NestJS avec le service name `lecopro-api`.
+
+### Variables d'environnement API
+
+```env
+OTEL_EXPORTER_OTLP_ENDPOINT=http://signoz-otel-collector:4318
+OTEL_SERVICE_NAME=lecopro-api
+```
+
+## Import des dashboards
+
+### Via l'UI SigNoz
+
+1. Aller sur SigNoz → **Dashboards** → **New Dashboard** → **Import JSON**
+2. Coller le contenu du fichier JSON
+3. Cliquer sur **Import**
+
+### Via l'API SigNoz
+
+```bash
+# Exemple avec curl
+curl -X POST "https://signoz.uat.lecopro.fr/api/v1/dashboards" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <API_KEY>" \
+  -d @api-overview.json
+```
+
+## Structure des dashboards
+
+Chaque dashboard contient :
+
+- **title** : Nom du dashboard
+- **description** : Description
+- **tags** : Tags pour le filtrage
+- **layout** : Positionnement des widgets (grille 12 colonnes)
+- **widgets** : Liste des panels avec leurs requêtes
+- **variables** : Variables de dashboard (optionnel)
+
+## Widgets types
+
+| Type | Description |
+|------|-------------|
+| `value` | Valeur unique (métrique instantanée) |
+| `graph` | Graphique timeline |
+| `bar` | Graphique en barres |
+| `pie` | Camembert |
+| `table` | Tableau de données |
+
+## Attributs OpenTelemetry utilisés
+
+### Traces HTTP
+
+- `service.name` : Nom du service (`lecopro-api`)
+- `http.method` : Méthode HTTP (GET, POST, etc.)
+- `http.route` : Route de l'endpoint
+- `http.status_code` : Code HTTP de réponse
+- `hasError` : Booléen indiquant une erreur
+- `durationNano` : Durée en nanosecondes
+
+### Traces Database
+
+- `db.system` : Système de BDD (postgresql)
+- `db.operation` : Type d'opération (SELECT, INSERT, etc.)
+- `db.statement` : Requête SQL
+- `db.sql.table` : Table concernée
+
+### Exceptions
+
+- `exception.type` : Type d'exception
+- `exception.message` : Message d'erreur
+
+## Thresholds
+
+Les dashboards incluent des seuils colorés pour alerter visuellement :
+
+- 🟢 **Vert** : Normal
+- 🟡 **Jaune** : Attention
+- 🔴 **Rouge** : Critique
+
+### Exemples de seuils
+
+| Métrique | Jaune | Rouge |
+|----------|-------|-------|
+| Taux d'erreur | > 1% | > 5% |
+| Latence P95 | > 500ms | > 2s |
+| Erreurs DB | > 0 | - |
+| Erreurs 5xx | > 1 | > 10 |
+
+## Personnalisation
+
+Pour ajouter de nouveaux widgets :
+
+1. Copier un widget existant similaire
+2. Modifier l'`id` (unique)
+3. Adapter les `filters` pour cibler les bonnes traces
+4. Ajuster le `layout` pour le positionnement
+5. Mettre à jour les `thresholds` si nécessaire

--- a/signoz/dashboards/api-auth.json
+++ b/signoz/dashboards/api-auth.json
@@ -1,0 +1,847 @@
+{
+  "title": "LeCopro - Authentification",
+  "description": "Monitoring des authentifications, tokens et sessions",
+  "tags": ["lecopro", "auth", "security", "jwt"],
+  "layout": [
+    {
+      "i": "login-attempts",
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "login-success",
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "login-failures",
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "token-refreshes",
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "auth-timeline",
+      "x": 0,
+      "y": 2,
+      "w": 12,
+      "h": 3
+    },
+    {
+      "i": "auth-by-endpoint",
+      "x": 0,
+      "y": 5,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "auth-failures-by-reason",
+      "x": 6,
+      "y": 5,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "auth-by-role",
+      "x": 0,
+      "y": 8,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "401-errors",
+      "x": 6,
+      "y": 8,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "auth-latency",
+      "x": 0,
+      "y": 11,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "auth-detail-table",
+      "x": 6,
+      "y": 11,
+      "w": 6,
+      "h": 3
+    }
+  ],
+  "widgets": [
+    {
+      "id": "login-attempts",
+      "title": "Tentatives de connexion",
+      "description": "Nombre total de tentatives de login",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth/login"
+                  },
+                  {
+                    "key": {
+                      "key": "http.method",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "POST"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Logins",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "login-success",
+      "title": "Connexions réussies",
+      "description": "Logins avec succès (HTTP 200/201)",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth/login"
+                  },
+                  {
+                    "key": {
+                      "key": "http.method",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "POST"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "<",
+                    "value": 300
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Succès",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "login-failures",
+      "title": "Échecs de connexion",
+      "description": "Logins échoués (401, 403, etc.)",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth/login"
+                  },
+                  {
+                    "key": {
+                      "key": "http.method",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "POST"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": ">=",
+                    "value": 400
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Échecs",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      },
+      "thresholds": [
+        {
+          "thresholdValue": 10,
+          "thresholdColor": "Yellow",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "none"
+        },
+        {
+          "thresholdValue": 50,
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "none"
+        }
+      ]
+    },
+    {
+      "id": "token-refreshes",
+      "title": "Refresh tokens",
+      "description": "Nombre de refresh de tokens",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth/refresh"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Refreshes",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "auth-timeline",
+      "title": "Activité d'authentification",
+      "description": "Logins et refreshes dans le temps",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth/login"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "<",
+                    "value": 300
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "Login OK"
+            },
+            {
+              "dataSource": "traces",
+              "queryName": "B",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth/login"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": ">=",
+                    "value": 400
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "B",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "Login KO"
+            },
+            {
+              "dataSource": "traces",
+              "queryName": "C",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth/refresh"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "C",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "Refresh"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "auth-by-endpoint",
+      "title": "Par endpoint auth",
+      "description": "Distribution des appels par endpoint",
+      "panelTypes": "pie",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.route",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.route}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "auth-failures-by-reason",
+      "title": "Échecs par code HTTP",
+      "description": "Distribution des erreurs d'auth",
+      "panelTypes": "bar",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": ">=",
+                    "value": 400
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.status_code",
+                  "dataType": "int64",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "HTTP {{http.status_code}}",
+              "orderBy": {
+                "columnName": "A",
+                "order": "desc"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "auth-by-role",
+      "title": "Par rôle utilisateur",
+      "description": "Connexions par rôle (si disponible)",
+      "panelTypes": "pie",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth/login"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "<",
+                    "value": 300
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "user.role",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{user.role}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "401-errors",
+      "title": "Erreurs 401 globales",
+      "description": "Toutes les erreurs 401 (non autorisé)",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": 401
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "groupBy": [
+                {
+                  "key": "http.route",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.route}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "auth-latency",
+      "title": "Latence auth",
+      "description": "Temps de réponse des endpoints auth",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A/1000000",
+              "disabled": false,
+              "stepInterval": 60,
+              "groupBy": [
+                {
+                  "key": "http.route",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.route}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "auth-detail-table",
+      "title": "Détails auth",
+      "description": "Résumé des appels auth par endpoint et status",
+      "panelTypes": "table",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.method",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                },
+                {
+                  "key": "http.route",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                },
+                {
+                  "key": "http.status_code",
+                  "dataType": "int64",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.method}} {{http.route}}",
+              "orderBy": {
+                "columnName": "A",
+                "order": "desc"
+              },
+              "limit": 20
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "variables": {}
+}

--- a/signoz/dashboards/api-business.json
+++ b/signoz/dashboards/api-business.json
@@ -1,0 +1,1037 @@
+{
+  "title": "LeCopro - Business Metrics",
+  "description": "Métriques métier spécifiques à l'application LeCopro",
+  "tags": ["lecopro", "business", "metrics", "copropriete"],
+  "layout": [
+    {
+      "i": "condos-created",
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "owners-created",
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "lots-created",
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "payments-initiated",
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "documents-uploaded",
+      "x": 0,
+      "y": 2,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "bank-syncs",
+      "x": 3,
+      "y": 2,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "utility-bills-created",
+      "x": 6,
+      "y": 2,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "meter-readings",
+      "x": 9,
+      "y": 2,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "business-timeline",
+      "x": 0,
+      "y": 4,
+      "w": 12,
+      "h": 3
+    },
+    {
+      "i": "condo-operations",
+      "x": 0,
+      "y": 7,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "owner-operations",
+      "x": 6,
+      "y": 7,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "payment-status",
+      "x": 0,
+      "y": 10,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "bank-operations",
+      "x": 6,
+      "y": 10,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "business-errors",
+      "x": 0,
+      "y": 13,
+      "w": 12,
+      "h": 3
+    }
+  ],
+  "widgets": [
+    {
+      "id": "condos-created",
+      "title": "Copropriétés créées",
+      "description": "POST /condominiums",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "/condominiums"
+                  },
+                  {
+                    "key": {
+                      "key": "http.method",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "POST"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "<",
+                    "value": 300
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Copros",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "owners-created",
+      "title": "Copropriétaires créés",
+      "description": "POST /owners",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/owners"
+                  },
+                  {
+                    "key": {
+                      "key": "http.method",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "POST"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "<",
+                    "value": 300
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Owners",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "lots-created",
+      "title": "Lots créés",
+      "description": "POST /lots",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/lots"
+                  },
+                  {
+                    "key": {
+                      "key": "http.method",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "POST"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "<",
+                    "value": 300
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Lots",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "payments-initiated",
+      "title": "Paiements initiés",
+      "description": "POST /payments",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/payments"
+                  },
+                  {
+                    "key": {
+                      "key": "http.method",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "POST"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "<",
+                    "value": 300
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Paiements",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "documents-uploaded",
+      "title": "Documents uploadés",
+      "description": "POST /documents",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/documents"
+                  },
+                  {
+                    "key": {
+                      "key": "http.method",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "POST"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "<",
+                    "value": 300
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Documents",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "bank-syncs",
+      "title": "Synchros bancaires",
+      "description": "Appels bank/sync",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/bank"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Bank ops",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "utility-bills-created",
+      "title": "Factures créées",
+      "description": "POST utility-bills",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "utility-bills"
+                  },
+                  {
+                    "key": {
+                      "key": "http.method",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "POST"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Factures",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "meter-readings",
+      "title": "Relevés compteurs",
+      "description": "POST meter-readings",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "meter-readings"
+                  },
+                  {
+                    "key": {
+                      "key": "http.method",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "POST"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Relevés",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "business-timeline",
+      "title": "Activité métier",
+      "description": "Création d'entités dans le temps",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/condominiums"
+                  },
+                  {
+                    "key": {
+                      "key": "http.method",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "POST"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "Copros"
+            },
+            {
+              "dataSource": "traces",
+              "queryName": "B",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/owners"
+                  },
+                  {
+                    "key": {
+                      "key": "http.method",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "POST"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "B",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "Owners"
+            },
+            {
+              "dataSource": "traces",
+              "queryName": "C",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/payments"
+                  },
+                  {
+                    "key": {
+                      "key": "http.method",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "POST"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "C",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "Paiements"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "condo-operations",
+      "title": "Opérations Copropriétés",
+      "description": "CRUD sur copropriétés",
+      "panelTypes": "bar",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/condominiums"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.method",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.method}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "owner-operations",
+      "title": "Opérations Copropriétaires",
+      "description": "CRUD sur copropriétaires",
+      "panelTypes": "bar",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/owners"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.method",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.method}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "payment-status",
+      "title": "Statuts paiements",
+      "description": "Répartition par code HTTP",
+      "panelTypes": "pie",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/payments"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.status_code",
+                  "dataType": "int64",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "HTTP {{http.status_code}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "bank-operations",
+      "title": "Opérations bancaires",
+      "description": "Appels aux endpoints bank",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/bank"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "groupBy": [
+                {
+                  "key": "http.route",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.route}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "business-errors",
+      "title": "Erreurs métier",
+      "description": "Erreurs sur les endpoints business critiques",
+      "panelTypes": "table",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "hasError",
+                      "dataType": "bool",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": true
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.method",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                },
+                {
+                  "key": "http.route",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                },
+                {
+                  "key": "http.status_code",
+                  "dataType": "int64",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.method}} {{http.route}}",
+              "orderBy": {
+                "columnName": "A",
+                "order": "desc"
+              },
+              "limit": 20
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "variables": {}
+}

--- a/signoz/dashboards/api-database.json
+++ b/signoz/dashboards/api-database.json
@@ -1,0 +1,759 @@
+{
+  "title": "LeCopro - Base de données",
+  "description": "Monitoring des opérations base de données (Drizzle ORM)",
+  "tags": ["lecopro", "database", "drizzle", "postgres"],
+  "layout": [
+    {
+      "i": "db-operations",
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "db-avg-latency",
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "db-p95-latency",
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "db-errors",
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "db-operations-timeline",
+      "x": 0,
+      "y": 2,
+      "w": 12,
+      "h": 3
+    },
+    {
+      "i": "db-latency-timeline",
+      "x": 0,
+      "y": 5,
+      "w": 12,
+      "h": 3
+    },
+    {
+      "i": "db-by-operation",
+      "x": 0,
+      "y": 8,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "db-slowest-queries",
+      "x": 6,
+      "y": 8,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "db-by-table",
+      "x": 0,
+      "y": 11,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "db-errors-detail",
+      "x": 6,
+      "y": 11,
+      "w": 6,
+      "h": 3
+    }
+  ],
+  "widgets": [
+    {
+      "id": "db-operations",
+      "title": "Opérations DB",
+      "description": "Nombre total d'opérations base de données",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "db.system",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Opérations",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "db-avg-latency",
+      "title": "Latence moyenne DB",
+      "description": "Temps moyen des requêtes DB",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "db.system",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A/1000000",
+              "disabled": false,
+              "legend": "ms",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      },
+      "thresholds": [
+        {
+          "thresholdValue": 50,
+          "thresholdColor": "Yellow",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "ms"
+        },
+        {
+          "thresholdValue": 200,
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "ms"
+        }
+      ]
+    },
+    {
+      "id": "db-p95-latency",
+      "title": "P95 Latence DB",
+      "description": "Latence 95ème percentile",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "p95",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "db.system",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A/1000000",
+              "disabled": false,
+              "legend": "ms",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      },
+      "thresholds": [
+        {
+          "thresholdValue": 100,
+          "thresholdColor": "Yellow",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "ms"
+        },
+        {
+          "thresholdValue": 500,
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "ms"
+        }
+      ]
+    },
+    {
+      "id": "db-errors",
+      "title": "Erreurs DB",
+      "description": "Nombre d'erreurs base de données",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "db.system",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  },
+                  {
+                    "key": {
+                      "key": "hasError",
+                      "dataType": "bool",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": true
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Erreurs",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      },
+      "thresholds": [
+        {
+          "thresholdValue": 1,
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "none"
+        }
+      ]
+    },
+    {
+      "id": "db-operations-timeline",
+      "title": "Opérations DB dans le temps",
+      "description": "Évolution du nombre de requêtes DB",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "db.system",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "Requêtes DB"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "db-latency-timeline",
+      "title": "Latences DB dans le temps",
+      "description": "Évolution des latences (avg, P95, P99)",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "db.system",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A/1000000",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "Avg"
+            },
+            {
+              "dataSource": "traces",
+              "queryName": "B",
+              "aggregateOperator": "p95",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "db.system",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "B/1000000",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "P95"
+            },
+            {
+              "dataSource": "traces",
+              "queryName": "C",
+              "aggregateOperator": "p99",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "db.system",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "C/1000000",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "P99"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "db-by-operation",
+      "title": "Par type d'opération",
+      "description": "Distribution SELECT, INSERT, UPDATE, DELETE",
+      "panelTypes": "pie",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "db.system",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "db.operation",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{db.operation}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "db-slowest-queries",
+      "title": "Requêtes les plus lentes",
+      "description": "Top 10 requêtes DB par latence",
+      "panelTypes": "table",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "db.system",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A/1000000",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "db.statement",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{db.statement}}",
+              "orderBy": {
+                "columnName": "A",
+                "order": "desc"
+              },
+              "limit": 10
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "db-by-table",
+      "title": "Par table",
+      "description": "Requêtes par table SQL",
+      "panelTypes": "bar",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "db.sql.table",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "db.sql.table",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{db.sql.table}}",
+              "orderBy": {
+                "columnName": "A",
+                "order": "desc"
+              },
+              "limit": 15
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "db-errors-detail",
+      "title": "Erreurs DB détaillées",
+      "description": "Détail des erreurs base de données",
+      "panelTypes": "table",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "db.system",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  },
+                  {
+                    "key": {
+                      "key": "hasError",
+                      "dataType": "bool",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": true
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "db.operation",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                },
+                {
+                  "key": "exception.message",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{db.operation}} - {{exception.message}}",
+              "orderBy": {
+                "columnName": "A",
+                "order": "desc"
+              },
+              "limit": 20
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "variables": {}
+}

--- a/signoz/dashboards/api-errors.json
+++ b/signoz/dashboards/api-errors.json
@@ -1,0 +1,749 @@
+{
+  "title": "LeCopro - Erreurs & Exceptions",
+  "description": "Suivi des erreurs, exceptions et codes HTTP 4xx/5xx",
+  "tags": ["lecopro", "errors", "exceptions"],
+  "layout": [
+    {
+      "i": "total-errors",
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "4xx-errors",
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "5xx-errors",
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "error-rate",
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "errors-timeline",
+      "x": 0,
+      "y": 2,
+      "w": 12,
+      "h": 3
+    },
+    {
+      "i": "errors-by-status",
+      "x": 0,
+      "y": 5,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "errors-by-endpoint",
+      "x": 6,
+      "y": 5,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "top-errors-table",
+      "x": 0,
+      "y": 8,
+      "w": 12,
+      "h": 4
+    },
+    {
+      "i": "exception-types",
+      "x": 0,
+      "y": 12,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "recent-exceptions",
+      "x": 6,
+      "y": 12,
+      "w": 6,
+      "h": 3
+    }
+  ],
+  "widgets": [
+    {
+      "id": "total-errors",
+      "title": "Total Erreurs",
+      "description": "Nombre total de requêtes en erreur",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "hasError",
+                      "dataType": "bool",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": true
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Erreurs",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      },
+      "thresholds": [
+        {
+          "thresholdValue": 10,
+          "thresholdColor": "Yellow",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "none"
+        },
+        {
+          "thresholdValue": 50,
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "none"
+        }
+      ]
+    },
+    {
+      "id": "4xx-errors",
+      "title": "Erreurs 4xx",
+      "description": "Erreurs client (400-499)",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": ">=",
+                    "value": 400
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "<",
+                    "value": 500
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "4xx",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "5xx-errors",
+      "title": "Erreurs 5xx",
+      "description": "Erreurs serveur (500-599)",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": ">=",
+                    "value": 500
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "5xx",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      },
+      "thresholds": [
+        {
+          "thresholdValue": 1,
+          "thresholdColor": "Yellow",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "none"
+        },
+        {
+          "thresholdValue": 10,
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "none"
+        }
+      ]
+    },
+    {
+      "id": "error-rate",
+      "title": "Taux d'erreur",
+      "description": "Pourcentage d'erreurs",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "hasError",
+                      "dataType": "bool",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": true
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false
+            },
+            {
+              "dataSource": "traces",
+              "queryName": "B",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "B",
+              "disabled": false
+            }
+          ],
+          "queryFormulas": [
+            {
+              "expression": "(A/B)*100",
+              "queryName": "F1",
+              "legend": "Taux (%)"
+            }
+          ]
+        }
+      },
+      "thresholds": [
+        {
+          "thresholdValue": 1,
+          "thresholdColor": "Yellow",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "none"
+        },
+        {
+          "thresholdValue": 5,
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "none"
+        }
+      ]
+    },
+    {
+      "id": "errors-timeline",
+      "title": "Erreurs dans le temps",
+      "description": "Évolution des erreurs 4xx et 5xx",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": ">=",
+                    "value": 400
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "<",
+                    "value": 500
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "4xx"
+            },
+            {
+              "dataSource": "traces",
+              "queryName": "B",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": ">=",
+                    "value": 500
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "B",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "5xx"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "errors-by-status",
+      "title": "Erreurs par code HTTP",
+      "description": "Distribution des codes d'erreur",
+      "panelTypes": "pie",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.status_code",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": ">=",
+                    "value": 400
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.status_code",
+                  "dataType": "int64",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "HTTP {{http.status_code}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "errors-by-endpoint",
+      "title": "Erreurs par endpoint",
+      "description": "Top endpoints avec le plus d'erreurs",
+      "panelTypes": "bar",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "hasError",
+                      "dataType": "bool",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": true
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.route",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.route}}",
+              "orderBy": {
+                "columnName": "A",
+                "order": "desc"
+              },
+              "limit": 10
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "top-errors-table",
+      "title": "Détails des erreurs",
+      "description": "Liste détaillée des erreurs récentes",
+      "panelTypes": "table",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "hasError",
+                      "dataType": "bool",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": true
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.method",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                },
+                {
+                  "key": "http.route",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                },
+                {
+                  "key": "http.status_code",
+                  "dataType": "int64",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.method}} {{http.route}} - {{http.status_code}}",
+              "orderBy": {
+                "columnName": "A",
+                "order": "desc"
+              },
+              "limit": 20
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "exception-types",
+      "title": "Types d'exceptions",
+      "description": "Distribution des types d'exceptions",
+      "panelTypes": "pie",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "exception.type",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "exception.type",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{exception.type}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "recent-exceptions",
+      "title": "Exceptions récentes",
+      "description": "Timeline des exceptions",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "exception.type",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "exists",
+                    "value": ""
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "groupBy": [
+                {
+                  "key": "exception.type",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{exception.type}}"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "variables": {}
+}

--- a/signoz/dashboards/api-modules.json
+++ b/signoz/dashboards/api-modules.json
@@ -1,0 +1,811 @@
+{
+  "title": "LeCopro - API par Module",
+  "description": "Suivi des appels API par module métier (Auth, Owners, Condominiums, etc.)",
+  "tags": ["lecopro", "api", "modules"],
+  "layout": [
+    {
+      "i": "auth-requests",
+      "x": 0,
+      "y": 0,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "owners-requests",
+      "x": 4,
+      "y": 0,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "condominiums-requests",
+      "x": 8,
+      "y": 0,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "auth-latency",
+      "x": 0,
+      "y": 2,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "owners-latency",
+      "x": 4,
+      "y": 2,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "condominiums-latency",
+      "x": 8,
+      "y": 2,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "payments-requests",
+      "x": 0,
+      "y": 4,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "bank-requests",
+      "x": 4,
+      "y": 4,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "documents-requests",
+      "x": 8,
+      "y": 4,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "module-distribution",
+      "x": 0,
+      "y": 6,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "module-errors",
+      "x": 6,
+      "y": 6,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "module-timeline",
+      "x": 0,
+      "y": 9,
+      "w": 12,
+      "h": 3
+    }
+  ],
+  "widgets": [
+    {
+      "id": "auth-requests",
+      "title": "Auth - Requêtes",
+      "description": "Nombre de requêtes sur /auth/*",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Auth",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "owners-requests",
+      "title": "Owners - Requêtes",
+      "description": "Nombre de requêtes sur /owners/*",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/owners"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Owners",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "condominiums-requests",
+      "title": "Condominiums - Requêtes",
+      "description": "Nombre de requêtes sur /condominiums/*",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/condominiums"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Condominiums",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "auth-latency",
+      "title": "Auth - Latence P95",
+      "description": "Latence P95 des endpoints Auth",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "p95",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A/1000000",
+              "disabled": false,
+              "legend": "P95 (ms)",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "owners-latency",
+      "title": "Owners - Latence P95",
+      "description": "Latence P95 des endpoints Owners",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "p95",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/owners"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A/1000000",
+              "disabled": false,
+              "legend": "P95 (ms)",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "condominiums-latency",
+      "title": "Condominiums - Latence P95",
+      "description": "Latence P95 des endpoints Condominiums",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "p95",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/condominiums"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A/1000000",
+              "disabled": false,
+              "legend": "P95 (ms)",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "payments-requests",
+      "title": "Payments - Requêtes",
+      "description": "Nombre de requêtes sur /payments/*",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/payments"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Payments",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "bank-requests",
+      "title": "Bank - Requêtes",
+      "description": "Nombre de requêtes sur /bank/*",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/bank"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Bank",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "documents-requests",
+      "title": "Documents - Requêtes",
+      "description": "Nombre de requêtes sur /documents/*",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/documents"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "legend": "Documents",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "module-distribution",
+      "title": "Distribution par module",
+      "description": "Répartition des requêtes par module API",
+      "panelTypes": "pie",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "kind",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": 2
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.route",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.route}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "module-errors",
+      "title": "Erreurs par module",
+      "description": "Nombre d'erreurs par module",
+      "panelTypes": "bar",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "hasError",
+                      "dataType": "bool",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": true
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.route",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.route}}",
+              "orderBy": {
+                "columnName": "A",
+                "order": "desc"
+              },
+              "limit": 10
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "module-timeline",
+      "title": "Timeline par module",
+      "description": "Évolution des requêtes par module dans le temps",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "auth",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/auth"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "auth",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "Auth"
+            },
+            {
+              "dataSource": "traces",
+              "queryName": "owners",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/owners"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "owners",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "Owners"
+            },
+            {
+              "dataSource": "traces",
+              "queryName": "condos",
+              "aggregateOperator": "count",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "http.route",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "contains",
+                    "value": "/condominiums"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "condos",
+              "disabled": false,
+              "stepInterval": 60,
+              "legend": "Condominiums"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "variables": {}
+}

--- a/signoz/dashboards/api-overview.json
+++ b/signoz/dashboards/api-overview.json
@@ -1,0 +1,674 @@
+{
+  "title": "LeCopro - API Overview",
+  "description": "Vue d'ensemble des appels API de l'application LeCopro",
+  "tags": ["lecopro", "api", "nestjs"],
+  "layout": [
+    {
+      "i": "requests-per-minute",
+      "x": 0,
+      "y": 0,
+      "w": 6,
+      "h": 2
+    },
+    {
+      "i": "error-rate",
+      "x": 6,
+      "y": 0,
+      "w": 6,
+      "h": 2
+    },
+    {
+      "i": "avg-latency",
+      "x": 0,
+      "y": 2,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "p95-latency",
+      "x": 4,
+      "y": 2,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "p99-latency",
+      "x": 8,
+      "y": 2,
+      "w": 4,
+      "h": 2
+    },
+    {
+      "i": "requests-by-endpoint",
+      "x": 0,
+      "y": 4,
+      "w": 12,
+      "h": 3
+    },
+    {
+      "i": "requests-by-status",
+      "x": 0,
+      "y": 7,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "top-slow-endpoints",
+      "x": 6,
+      "y": 7,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "requests-timeline",
+      "x": 0,
+      "y": 10,
+      "w": 12,
+      "h": 3
+    }
+  ],
+  "widgets": [
+    {
+      "id": "requests-per-minute",
+      "title": "Requêtes / minute",
+      "description": "Nombre total de requêtes par minute",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "kind",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": 2
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "groupBy": [],
+              "legend": "Requêtes/min",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "error-rate",
+      "title": "Taux d'erreur (%)",
+      "description": "Pourcentage de requêtes en erreur",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "hasError",
+                      "dataType": "bool",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": true
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false
+            },
+            {
+              "dataSource": "traces",
+              "queryName": "B",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "B",
+              "disabled": false
+            }
+          ],
+          "queryFormulas": [
+            {
+              "expression": "(A/B)*100",
+              "queryName": "F1",
+              "legend": "Taux d'erreur"
+            }
+          ]
+        }
+      },
+      "thresholds": [
+        {
+          "thresholdValue": 1,
+          "thresholdColor": "Yellow",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "none"
+        },
+        {
+          "thresholdValue": 5,
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdUnit": "none"
+        }
+      ]
+    },
+    {
+      "id": "avg-latency",
+      "title": "Latence moyenne",
+      "description": "Temps de réponse moyen des API",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "kind",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": 2
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A/1000000",
+              "disabled": false,
+              "legend": "Latence (ms)",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "p95-latency",
+      "title": "Latence P95",
+      "description": "95ème percentile de latence",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "p95",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "kind",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": 2
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A/1000000",
+              "disabled": false,
+              "legend": "P95 (ms)",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "p99-latency",
+      "title": "Latence P99",
+      "description": "99ème percentile de latence",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "p99",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "kind",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": 2
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A/1000000",
+              "disabled": false,
+              "legend": "P99 (ms)",
+              "reduceTo": "last"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "requests-by-endpoint",
+      "title": "Requêtes par endpoint",
+      "description": "Distribution des requêtes par route API",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "kind",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": 2
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "groupBy": [
+                {
+                  "key": "http.route",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.route}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "requests-by-status",
+      "title": "Requêtes par code HTTP",
+      "description": "Distribution des codes de statut HTTP",
+      "panelTypes": "pie",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "kind",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": 2
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.status_code",
+                  "dataType": "int64",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "HTTP {{http.status_code}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "top-slow-endpoints",
+      "title": "Top 10 endpoints les plus lents",
+      "description": "Endpoints avec la latence moyenne la plus élevée",
+      "panelTypes": "table",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "kind",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": 2
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A/1000000",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "http.route",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                },
+                {
+                  "key": "http.method",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{http.method}} {{http.route}}",
+              "orderBy": {
+                "columnName": "A",
+                "order": "desc"
+              },
+              "limit": 10
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "requests-timeline",
+      "title": "Timeline des requêtes",
+      "description": "Évolution du nombre de requêtes dans le temps",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "traces",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "kind",
+                      "dataType": "int64",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": 2
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "groupBy": [],
+              "legend": "Requêtes"
+            },
+            {
+              "dataSource": "traces",
+              "queryName": "B",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "isColumn": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "service.name",
+                      "dataType": "string",
+                      "type": "resource",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "lecopro-api"
+                  },
+                  {
+                    "key": {
+                      "key": "hasError",
+                      "dataType": "bool",
+                      "type": "tag",
+                      "isColumn": true
+                    },
+                    "op": "=",
+                    "value": true
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "B",
+              "disabled": false,
+              "stepInterval": 60,
+              "groupBy": [],
+              "legend": "Erreurs"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "variables": {}
+}


### PR DESCRIPTION
## Changements

### Fix page Owners
- Correction de l'erreur `SelectItem must have a value prop that is not an empty string`
- Utilisation de 'all' au lieu de '' pour l'option 'Toutes les copropriétés'

### SigNoz Dashboards
Ajout de 6 dashboards JSON pour le monitoring API :
- **api-overview.json** : Vue d'ensemble (requêtes/min, latences, erreurs)
- **api-modules.json** : Métriques par module (Auth, Owners, Condos, etc.)
- **api-errors.json** : Suivi des erreurs HTTP 4xx/5xx et exceptions
- **api-database.json** : Monitoring des opérations DB (Drizzle/PostgreSQL)
- **api-auth.json** : Authentification, tokens, sessions
- **api-business.json** : Métriques métier (créations, paiements, synchros)