### PR TITLE
docs: update milestones list (remove Phase references)

### DIFF
--- a/context/_context.md
+++ b/context/_context.md
@@ -40,9 +40,7 @@ Objectif : permettre à un agent IA (ou un nouveau dev) de comprendre rapidement
    - Liste des tâches par domaine fonctionnel (Auth, Platform Admin, Manager, Portails, Bank, Documents, IA, Infrastructure)  
    - Suivi de l'avancement du projet  
    - Correspond aux milestones GitHub — vérifier la liste courante sur GitHub. Exemples de milestones actuellement utilisés :
-     - Phase 1: Setup & Infrastructure
-     - Phase 7: Integrations
-     - Infrastructure
+   - Infrastructure
      - Auth & Users
      - Bank & Payments
      - IA & Automation

--- a/context/todolist.md
+++ b/context/todolist.md
@@ -172,8 +172,6 @@
 
 Exemples de milestones actuellement utilisés sur GitHub :
 
-- Phase 1: Setup & Infrastructure
-- Phase 7: Integrations
 - Infrastructure
 - Auth & Users
 - Bank & Payments


### PR DESCRIPTION
## Description
Les fichiers de contexte mentionnaient encore les anciennes milestones de type 'Phase X'.
Ce PR met a jour context/_context.md et context/todolist.md pour lister uniquement les milestones concretes utilisees sur GitHub :

- Infrastructure
- Auth & Users
- Bank & Payments
- IA & Automation
- Manager Backoffice
- Platform Admin
- Portail Coproprietaire
- Portail Locataire
- No Milestone

## Fichiers modifies
- context/_context.md
- context/todolist.md