### PR TITLE
fix: prevent duplicate workflow runs on PR merge

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,6 +12,7 @@ on:
       - 'LICENSE'
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - 'context/**'
       - '*.md'


### PR DESCRIPTION
Add `types: [opened, synchronize, reopened]` to pull_request trigger so the workflow doesn't fire when a PR is closed/merged.

This prevents having 2 workflow runs when merging a PR into main (one from pull_request and one from push).