### PR TITLE
feat(owners): add owner detail page with tenant-scoped data

### DIFF
--- a/apps/web/src/app/app/condominiums/[id]/owners/page.tsx
+++ b/apps/web/src/app/app/condominiums/[id]/owners/page.tsx
@@ -595,7 +595,7 @@ export default function OwnersPage({ params }: { params: Promise<{ id: string }>
                 >
                   <TableCell className="h-12 px-4 font-medium">
                     <Link
-                      href={`/app/condominiums/${condoId}/owners/${owner.id}`}
+                      href={`/app/owners/${owner.id}`}
                       className="hover:text-primary hover:underline"
                     >
                       {owner.name}
@@ -657,7 +657,7 @@ export default function OwnersPage({ params }: { params: Promise<{ id: string }>
                       <DropdownMenuContent align="end" className="w-40">
                         <DropdownMenuItem asChild>
                           <Link
-                            href={`/app/condominiums/${condoId}/owners/${owner.id}`}
+                            href={`/app/owners/${owner.id}`}
                             className="flex items-center"
                           >
                             <Eye className="mr-2 h-4 w-4" />

--- a/apps/web/src/app/app/owners/[ownerId]/page.tsx
+++ b/apps/web/src/app/app/owners/[ownerId]/page.tsx
@@ -1,0 +1,470 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  ArrowLeft,
+  User,
+  Mail,
+  Building2,
+  Home,
+  CreditCard,
+  Receipt,
+  CheckCircle2,
+  Clock,
+  AlertTriangle,
+  Loader2,
+  Calendar,
+  Euro,
+  FileText,
+  ChevronRight,
+} from "lucide-react";
+
+interface OwnerLot {
+  id: string;
+  reference: string;
+  type: string;
+  floor: number | null;
+  surface: number | null;
+  shares: number | null;
+}
+
+interface OwnerCondominium {
+  id: string;
+  name: string;
+  address: string;
+  city: string;
+  lots: OwnerLot[];
+}
+
+interface OwnerPayment {
+  id: string;
+  amount: number;
+  paidAmount: number | null;
+  status: string;
+  type: string;
+  description: string | null;
+  dueDate: string;
+  paidAt: string | null;
+  condominiumId: string;
+  condominiumName: string;
+}
+
+interface OwnerMandate {
+  id: string;
+  status: string;
+  iban: string;
+  bic: string | null;
+  signedAt: string | null;
+  createdAt: string;
+}
+
+interface OwnerDetails {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  status: string;
+  createdAt: string;
+  condominiums: OwnerCondominium[];
+  payments: OwnerPayment[];
+  balance: number;
+  mandates: OwnerMandate[];
+  hasSepaMandateActive: boolean;
+  stats: {
+    totalLots: number;
+    totalCondominiums: number;
+    pendingPayments: number;
+  };
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const config: Record<string, { label: string; bgColor: string; textColor: string; icon: React.ReactNode }> = {
+    active: { 
+      label: "Actif", 
+      bgColor: "bg-emerald-100 dark:bg-emerald-950", 
+      textColor: "text-emerald-700 dark:text-emerald-400",
+      icon: <CheckCircle2 className="h-3 w-3" />
+    },
+    pending: { 
+      label: "En attente", 
+      bgColor: "bg-amber-100 dark:bg-amber-950", 
+      textColor: "text-amber-700 dark:text-amber-400",
+      icon: <Clock className="h-3 w-3" />
+    },
+    invited: { 
+      label: "Invité", 
+      bgColor: "bg-blue-100 dark:bg-blue-950", 
+      textColor: "text-blue-700 dark:text-blue-400",
+      icon: <Mail className="h-3 w-3" />
+    },
+    suspended: { 
+      label: "Suspendu", 
+      bgColor: "bg-red-100 dark:bg-red-950", 
+      textColor: "text-red-700 dark:text-red-400",
+      icon: <AlertTriangle className="h-3 w-3" />
+    },
+  };
+
+  const statusConfig = config[status] || { 
+    label: status, 
+    bgColor: "bg-gray-100 dark:bg-gray-800", 
+    textColor: "text-gray-700 dark:text-gray-400",
+    icon: null
+  };
+
+  return (
+    <Badge variant="secondary" className={`${statusConfig.bgColor} ${statusConfig.textColor} border-0 gap-1`}>
+      {statusConfig.icon}
+      {statusConfig.label}
+    </Badge>
+  );
+}
+
+function PaymentStatusBadge({ status }: { status: string }) {
+  const config: Record<string, { label: string; bgColor: string; textColor: string }> = {
+    paid: { label: "Payé", bgColor: "bg-emerald-100 dark:bg-emerald-950", textColor: "text-emerald-700 dark:text-emerald-400" },
+    pending: { label: "En attente", bgColor: "bg-amber-100 dark:bg-amber-950", textColor: "text-amber-700 dark:text-amber-400" },
+    partial: { label: "Partiel", bgColor: "bg-blue-100 dark:bg-blue-950", textColor: "text-blue-700 dark:text-blue-400" },
+    overdue: { label: "En retard", bgColor: "bg-red-100 dark:bg-red-950", textColor: "text-red-700 dark:text-red-400" },
+  };
+
+  const statusConfig = config[status] || { label: status, bgColor: "bg-gray-100", textColor: "text-gray-700" };
+
+  return (
+    <Badge variant="secondary" className={`${statusConfig.bgColor} ${statusConfig.textColor} border-0`}>
+      {statusConfig.label}
+    </Badge>
+  );
+}
+
+export default function OwnerDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const ownerId = params.ownerId as string;
+
+  const [owner, setOwner] = useState<OwnerDetails | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchOwner = async () => {
+      try {
+        setLoading(true);
+        const response = await fetch(`/api/owners/${ownerId}`);
+        if (!response.ok) {
+          if (response.status === 404) {
+            setError("Propriétaire non trouvé");
+          } else {
+            setError("Erreur lors du chargement");
+          }
+          return;
+        }
+        const data = await response.json();
+        setOwner(data);
+      } catch (err) {
+        setError("Erreur de connexion");
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (ownerId) {
+      fetchOwner();
+    }
+  }, [ownerId]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[400px] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (error || !owner) {
+    return (
+      <div className="space-y-6">
+        <Button variant="ghost" size="sm" onClick={() => router.back()}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Retour
+        </Button>
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center py-12">
+            <AlertTriangle className="h-12 w-12 text-muted-foreground mb-4" />
+            <p className="text-muted-foreground">{error || "Propriétaire non trouvé"}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString("fr-FR", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+    });
+  };
+
+  const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat("fr-FR", {
+      style: "currency",
+      currency: "EUR",
+    }).format(amount);
+  };
+
+  const maskIban = (iban: string) => {
+    if (iban.length < 8) return iban;
+    return iban.slice(0, 4) + " •••• •••• " + iban.slice(-4);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <div className="flex-1">
+          <div className="flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+              <span className="text-lg font-semibold text-primary">
+                {owner.firstName[0]}{owner.lastName[0]}
+              </span>
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold">{owner.firstName} {owner.lastName}</h1>
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Mail className="h-4 w-4" />
+                <span>{owner.email}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <StatusBadge status={owner.status} />
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100 dark:bg-blue-950">
+                <Home className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{owner.stats.totalLots}</p>
+                <p className="text-sm text-muted-foreground">Lots</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-violet-100 dark:bg-violet-950">
+                <Building2 className="h-5 w-5 text-violet-600 dark:text-violet-400" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{owner.stats.totalCondominiums}</p>
+                <p className="text-sm text-muted-foreground">Copropriétés</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className={`flex h-10 w-10 items-center justify-center rounded-lg ${owner.balance < 0 ? 'bg-red-100 dark:bg-red-950' : 'bg-emerald-100 dark:bg-emerald-950'}`}>
+                <Euro className={`h-5 w-5 ${owner.balance < 0 ? 'text-red-600 dark:text-red-400' : 'text-emerald-600 dark:text-emerald-400'}`} />
+              </div>
+              <div>
+                <p className={`text-2xl font-bold ${owner.balance < 0 ? 'text-red-600 dark:text-red-400' : ''}`}>
+                  {formatCurrency(owner.balance)}
+                </p>
+                <p className="text-sm text-muted-foreground">Solde</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className={`flex h-10 w-10 items-center justify-center rounded-lg ${owner.hasSepaMandateActive ? 'bg-emerald-100 dark:bg-emerald-950' : 'bg-gray-100 dark:bg-gray-800'}`}>
+                <CreditCard className={`h-5 w-5 ${owner.hasSepaMandateActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-500'}`} />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{owner.hasSepaMandateActive ? "Actif" : "Aucun"}</p>
+                <p className="text-sm text-muted-foreground">Mandat SEPA</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Condominiums & Lots */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Building2 className="h-5 w-5" />
+            Copropriétés & Lots
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {owner.condominiums.length === 0 ? (
+            <p className="text-muted-foreground text-center py-8">Aucune copropriété associée</p>
+          ) : (
+            <div className="space-y-4">
+              {owner.condominiums.map((condo) => (
+                <div key={condo.id} className="border rounded-lg p-4">
+                  <div className="flex items-start justify-between mb-3">
+                    <div>
+                      <Link 
+                        href={`/app/condominiums/${condo.id}`}
+                        className="font-semibold hover:text-primary flex items-center gap-1"
+                      >
+                        {condo.name}
+                        <ChevronRight className="h-4 w-4" />
+                      </Link>
+                      <p className="text-sm text-muted-foreground">{condo.address}, {condo.city}</p>
+                    </div>
+                    <Badge variant="secondary">{condo.lots.length} lot(s)</Badge>
+                  </div>
+                  {condo.lots.length > 0 && (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+                      {condo.lots.map((lot) => (
+                        <div key={lot.id} className="flex items-center gap-2 bg-muted/50 rounded-md px-3 py-2">
+                          <Home className="h-4 w-4 text-muted-foreground" />
+                          <div>
+                            <p className="font-medium text-sm">{lot.reference}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {lot.type}
+                              {lot.surface && ` • ${lot.surface} m²`}
+                              {lot.shares && ` • ${lot.shares} tantièmes`}
+                            </p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Payment History */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Receipt className="h-5 w-5" />
+            Historique des paiements
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {owner.payments.length === 0 ? (
+            <p className="text-muted-foreground text-center py-8">Aucun paiement</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead>Copropriété</TableHead>
+                    <TableHead className="text-right">Montant</TableHead>
+                    <TableHead className="text-center">Statut</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {owner.payments.map((payment) => (
+                    <TableRow key={payment.id}>
+                      <TableCell className="whitespace-nowrap">
+                        <div className="flex items-center gap-2">
+                          <Calendar className="h-4 w-4 text-muted-foreground" />
+                          {formatDate(payment.dueDate)}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div>
+                          <p className="font-medium">{payment.type}</p>
+                          {payment.description && (
+                            <p className="text-sm text-muted-foreground">{payment.description}</p>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>{payment.condominiumName}</TableCell>
+                      <TableCell className="text-right font-medium">
+                        {formatCurrency(payment.amount)}
+                        {payment.paidAmount && payment.paidAmount > 0 && payment.paidAmount < payment.amount && (
+                          <p className="text-xs text-muted-foreground">
+                            Payé: {formatCurrency(payment.paidAmount)}
+                          </p>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <PaymentStatusBadge status={payment.status} />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* SEPA Mandates */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <CreditCard className="h-5 w-5" />
+            Mandats SEPA
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {owner.mandates.length === 0 ? (
+            <p className="text-muted-foreground text-center py-8">Aucun mandat SEPA</p>
+          ) : (
+            <div className="space-y-3">
+              {owner.mandates.map((mandate) => (
+                <div key={mandate.id} className="flex items-center justify-between border rounded-lg p-4">
+                  <div className="flex items-center gap-4">
+                    <CreditCard className={`h-8 w-8 ${mandate.status === 'active' ? 'text-emerald-500' : 'text-muted-foreground'}`} />
+                    <div>
+                      <p className="font-mono font-medium">{maskIban(mandate.iban)}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {mandate.signedAt ? `Signé le ${formatDate(mandate.signedAt)}` : `Créé le ${formatDate(mandate.createdAt)}`}
+                      </p>
+                    </div>
+                  </div>
+                  <Badge variant={mandate.status === 'active' ? 'default' : 'secondary'}>
+                    {mandate.status === 'active' ? 'Actif' : mandate.status === 'revoked' ? 'Révoqué' : mandate.status}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/app/owners/page.tsx
+++ b/apps/web/src/app/app/owners/page.tsx
@@ -1083,7 +1083,7 @@ export default function OwnersPage() {
             return (
               <div key={owner.id} className="rounded-lg border bg-card p-4">
                 <div className="flex items-start justify-between gap-3">
-                  <Link href={owner.condominiumIds?.[0] ? `/app/condominiums/${owner.condominiumIds[0]}/owners/${owner.id}` : '#'} className="flex items-center gap-3 flex-1 min-w-0">
+                  <Link href={`/app/owners/${owner.id}`} className="flex items-center gap-3 flex-1 min-w-0">
                     <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10">
                       <span className="text-sm font-semibold text-primary">
                         {owner.firstName[0]}{owner.lastName[0]}
@@ -1104,7 +1104,7 @@ export default function OwnersPage() {
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
                         <DropdownMenuItem asChild>
-                          <Link href={owner.condominiumIds?.[0] ? `/app/condominiums/${owner.condominiumIds[0]}/owners/${owner.id}` : '#'}>
+                          <Link href={`/app/owners/${owner.id}`}>
                             <Eye className="mr-2 h-4 w-4" />
                             Voir le profil
                           </Link>
@@ -1197,7 +1197,7 @@ export default function OwnersPage() {
                           </span>
                         </div>
                         <Link
-                          href={owner.condominiumIds?.[0] ? `/app/condominiums/${owner.condominiumIds[0]}/owners/${owner.id}` : '#'}
+                          href={`/app/owners/${owner.id}`}
                           className="font-medium hover:underline"
                         >
                           {owner.firstName} {owner.lastName}
@@ -1254,7 +1254,7 @@ export default function OwnersPage() {
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
                           <DropdownMenuItem asChild>
-                            <Link href={owner.condominiumIds?.[0] ? `/app/condominiums/${owner.condominiumIds[0]}/owners/${owner.id}` : '#'}>
+                            <Link href={`/app/owners/${owner.id}`}>
                               <Eye className="mr-2 h-4 w-4" />
                               Voir le profil
                             </Link>

--- a/context/pages.md
+++ b/context/pages.md
@@ -154,18 +154,34 @@
   - View owner profile
   - Invite owner
 
-### 3.8 Owner Profile Page (Manager View)
-- Overview:
-  - Contact info
-  - Lots owned
-  - Current balance
-- Payments:
-  - Due schedule
-  - Payment history
+### 3.8b Owner Profile Page (/app/owners/[ownerId])
+> Tenant-scoped page showing all owner data across all condominiums within the tenant.
+> RGPD compliant: data automatically filtered by tenant via JWT.
+
+- Header:
+  - Owner name and email
+  - Status badge (active / pending / invited / managed)
+  - Back navigation
+- Stats cards:
+  - Total balance (all condominiums)
+  - Lots count
+  - Payments count
   - SEPA mandate status
-- Documents:
-  - Owner-related documents
-- Consumption (if enabled)
+- Condominiums section:
+  - List of all condominiums where owner has lots
+  - For each condominium:
+    - Condominium name and address
+    - Lots owned (type, quotas, floor)
+    - Link to condominium
+- Payment history:
+  - Last 20 payments across all condominiums
+  - Columns: Date, Amount, Condominium, Status
+  - Status badges (paid / pending / failed)
+- SEPA Mandates:
+  - List of all mandates
+  - Status (active / pending / revoked)
+  - Bank account (masked IBAN)
+  - Signature date
 
 ### 3.9 Documents Page (Modal / Panel)
 - Documents list

--- a/context/routes.md
+++ b/context/routes.md
@@ -66,11 +66,13 @@
 - /app/condominiums/[id]/utilities/new      # Create utility bill with readings
 
 ### 3.4 Owners
-- /app/condominiums/[id]/owners
-- /app/condominiums/[id]/owners/new
-- /app/condominiums/[id]/owners/[ownerId]
-- /app/condominiums/[id]/owners/[ownerId]/balance
-- /app/condominiums/[id]/owners/[ownerId]/mandates
+- /app/owners                         # List all owners for tenant (with pagination & filters)
+- /app/owners/new                     # Create new owner
+- /app/owners/[ownerId]               # Owner detail page (all condos, lots, payments, mandates)
+- /app/owners/[ownerId]/balance       # Owner balance details
+- /app/owners/[ownerId]/mandates      # Owner SEPA mandates
+- /app/condominiums/[id]/owners       # List owners for a specific condominium
+- /app/condominiums/[id]/owners/new   # Add owner to specific condominium
 
 ### 3.5 Tenants (Locataires)
 - /app/condominiums/[id]/locataires

--- a/context/use_case.md
+++ b/context/use_case.md
@@ -91,6 +91,13 @@ Platform Admin (you)
 - Add / remove a tenant from a condominium
 - Assign lots to owners and tenants
 - View owners list for a condominium (with status badges: active, invited, pending)
+- View all owners for tenant (global list with pagination and filters)
+- View owner detail page:
+  - Overview (contact info, status)
+  - All condominiums and lots (across tenant, RGPD compliant)
+  - Payment history (last 20 payments)
+  - SEPA mandates (active, pending, revoked)
+  - Total balance
 
 ### 3.3 Dues & Payment Plans
 - Define monthly advance payments (acompte)


### PR DESCRIPTION
## Description

Création d'une page de détail propriétaire accessible via `/app/owners/[ownerId]` avec toutes les données du propriétaire filtrées par tenant.

## Changements

### API (Backend)
- Enrichissement de `GET /owners/:id` pour retourner:
  - Informations du propriétaire
  - Liste des copropriétés avec lots
  - Historique des paiements (20 derniers)
  - Mandats SEPA
  - Solde total
  - Statistiques

### Frontend
- Nouvelle page `/app/owners/[ownerId]` avec:
  - En-tête avec nom, email et statut
  - Cards statistiques (solde, lots, paiements, SEPA)
  - Section copropriétés et lots
  - Historique des paiements
  - Mandats SEPA
- Mise à jour de tous les liens vers propriétaires

### Documentation
- `routes.md`: Nouvelle architecture des routes owners
- `pages.md`: Description détaillée de la page Owner Profile
- `use_case.md`: Cas d'utilisation enrichis pour la gestion des propriétaires

## RGPD
Les données propriétaires sont automatiquement filtrées par le tenant via le JWT - un syndic ne peut voir que ses propres propriétaires.

## Tests
- [x] Pas d'erreurs TypeScript
- [ ] Test manuel de navigation